### PR TITLE
Fix issue with email not displayed where needed

### DIFF
--- a/front-end/src/views/ApplicantHomePage/index.vue
+++ b/front-end/src/views/ApplicantHomePage/index.vue
@@ -313,7 +313,7 @@ export default {
               },
               {
                 name: `Личная почта${type[1]}`,
-                content: data.family[counter].contact_info?.personal_phone_number,
+                content: data.family[counter].contact_info?.personal_email,
               },
               {
                 name: `Номер телефона${type[1]}`,


### PR DESCRIPTION
Исправлена ошибка отображения номера телефона вместо электронной почты у родственников абитуриента