### PR TITLE
Add postgres data volume

### DIFF
--- a/dev-dc.yaml
+++ b/dev-dc.yaml
@@ -17,6 +17,8 @@ services:
     env_file:
       - .env
     restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
 
   ofelia:
     image: mcuadros/ofelia:latest
@@ -56,7 +58,6 @@ services:
       sh -c "/tools/wait-for-it.sh $POSTGRES_HOST:$POSTGRES_PORT -t 0 &&
              python manage.py migrate &&
              python manage.py register_permissions &&
-             python manage.py populate &&
              python manage.py runserver 0.0.0.0:$BACK_END_PORT"
     restart: unless-stopped
     volumes:
@@ -97,3 +98,6 @@ services:
       - ./tgbot:/tgbot
     # depends_on:
     #   - back-end
+
+volumes:
+  postgres-data:

--- a/prod-dc.yaml
+++ b/prod-dc.yaml
@@ -17,6 +17,8 @@ services:
     env_file:
       - .env
     restart: always
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
 
   ofelia:
     image: mcuadros/ofelia:latest


### PR DESCRIPTION
Добавляем volume для postgres, чтобы при удалении контейнера (например, при docker-compose down) не удалялись все данные.

В частности это означает, что в dev-е можно не делать populate при каждом старте контейнера. При желании можно запустить populate из контейнера с помощью

`docker exec -it back-end bash -c "python3 manage.py populate"`