### PR TITLE
feat(ams): ручка ручной заливки результатов ФИЗО + мм:сс в протоколе

### DIFF
--- a/back-end/src/ams/models/physical.py
+++ b/back-end/src/ams/models/physical.py
@@ -36,9 +36,10 @@ class ExerciseResult(models.Model):
 
     def save(self, *args, **kwargs):
         """Автоматический пересчет баллов при сохранении."""
-        # Избегаем рекурсии: если обновляется только secondary_score, не пересчитываем
+        # Избегаем рекурсии: если обновляется только secondary_score, не пересчитываем.
+        # `_skip_recalc` — ручной ввод результатов комиссии (балл задаётся дословно).
         update_fields = kwargs.get("update_fields")
-        should_recalculate = (
+        should_recalculate = not getattr(self, "_skip_recalc", False) and (
             update_fields is None
             or "secondary_score" not in update_fields
             or len(update_fields) > 1
@@ -56,6 +57,10 @@ class ExerciseResult(models.Model):
 @receiver(post_delete, sender=ExerciseResult)
 def recalculate_on_delete(sender, instance, **kwargs):
     """Пересчет баллов при удалении результата."""
+    # При ручной замене результатов (override) пересчёт подавляется.
+    if getattr(instance, "_skip_recalc", False):
+        return
+
     from ams.physical.recalculate import recalculate_physical_scores
 
     recalculate_physical_scores(instance.application_process)

--- a/back-end/src/ams/serializers/physical.py
+++ b/back-end/src/ams/serializers/physical.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from ams.models.physical import ExerciseResult
+from ams.physical.exercises import ExerciseType
 
 
 class ExerciseResultSerializer(serializers.ModelSerializer):
@@ -81,3 +82,31 @@ class ExerciseDefinitionSerializer(serializers.Serializer):
     unit = serializers.CharField()
     extra_params = serializers.ListField(child=serializers.CharField())
     higher_is_better = serializers.BooleanField()
+
+
+class ExerciseResultOverrideItemSerializer(serializers.Serializer):
+    """Один результат при ручной (дословной) загрузке данных комиссии.
+
+    В отличие от `ExerciseResultSerializer`, `secondary_score` записывается
+    напрямую и НЕ пересчитывается из `value`. Валидацию `extra_params` по
+    определению упражнения намеренно не выполняем — вводим числа дословно.
+    """
+
+    exercise_type = serializers.ChoiceField(choices=ExerciseType.choices)
+    value = serializers.FloatField()
+    secondary_score = serializers.IntegerField(min_value=0, max_value=100)
+    extra_params = serializers.JSONField(required=False, default=dict)
+
+
+class PhysicalOverrideSerializer(serializers.Serializer):
+    """Полная (дословная) выгрузка физ. результатов абитуриента от комиссии.
+
+    Заменяет весь набор результатов и выставляет агрегаты напрямую, без
+    вызова калькулятора баллов.
+    """
+
+    results = ExerciseResultOverrideItemSerializer(many=True)
+    strength_score = serializers.IntegerField(min_value=0, max_value=100)
+    speed_score = serializers.IntegerField(min_value=0, max_value=100)
+    endurance_score = serializers.IntegerField(min_value=0, max_value=100)
+    physical_test_grade = serializers.IntegerField(min_value=0, max_value=100)

--- a/back-end/src/ams/tests/conftest.py
+++ b/back-end/src/ams/tests/conftest.py
@@ -1,0 +1,65 @@
+# pylint: disable=redefined-outer-name,invalid-name
+from datetime import date
+
+import pytest
+
+from auth.models import User
+from common.models.personal import BirthInfo, ContactInfo, Passport
+from common.models.universities import Faculty, Program, UniversityInfo
+from common.models.milspecialties import Milspecialty
+
+from ams.models.applicants import Applicant, ApplicationProcess
+
+
+@pytest.fixture
+def application_process(db):
+    """Пустой ApplicationProcess (все поля с дефолтами)."""
+    return ApplicationProcess.objects.create()
+
+
+@pytest.fixture
+def applicant(db):
+    """Минимальный абитуриент со всеми обязательными связями."""
+    user = User.objects.create_user(
+        email="override_applicant@edu.hse.ru", password="qwerty"
+    )
+    birth = BirthInfo.objects.create(
+        date=date(2007, 3, 7), country="Россия", place="Москва"
+    )
+    passport = Passport.objects.create(
+        series="1000",
+        code="222222",
+        ufms_name="УФМС",
+        ufms_code="740-056",
+        issue_date=date(2020, 10, 2),
+    )
+    contact = ContactInfo.objects.create(
+        corporate_email="override@edu.hse.ru",
+        personal_email="override@ovr.ru",
+        personal_phone_number="79990000000",
+    )
+    faculty = Faculty.objects.create(campus="MO", title="ФКН", abbreviation="ФКН")
+    program = Program.objects.create(code="09.03.01", title="ИВТ", faculty=faculty)
+    uni = UniversityInfo.objects.create(
+        program=program, group="ГР", card_id="CARD", graduation_year=2024
+    )
+    milspec = Milspecialty.objects.create(
+        title="ВУС", code="453100", available_for=["MO"]
+    )
+    ap = ApplicationProcess.objects.create()
+    return Applicant.objects.create(
+        surname="Тестов",
+        name="Тест",
+        patronymic="Тестович",
+        surname_genitive="Тестова",
+        name_genitive="Теста",
+        patronymic_genitive="Тестовича",
+        recruitment_office="Военкомат",
+        birth_info=birth,
+        passport=passport,
+        university_info=uni,
+        contact_info=contact,
+        application_process=ap,
+        milspecialty=milspec,
+        user=user,
+    )

--- a/back-end/src/ams/tests/test_physical_override.py
+++ b/back-end/src/ams/tests/test_physical_override.py
@@ -158,9 +158,7 @@ def test_override_replaces_stale_results(su_client, applicant):
     )
     assert resp.status_code == 200
 
-    types = set(
-        ap.exercise_results.values_list("exercise_type", flat=True)
-    )
+    types = set(ap.exercise_results.values_list("exercise_type", flat=True))
     assert types == {"PULL_UPS", "RUN_60", "RUN_1K"}  # RUN_3K удалён
 
 

--- a/back-end/src/ams/tests/test_physical_override.py
+++ b/back-end/src/ams/tests/test_physical_override.py
@@ -1,0 +1,174 @@
+# pylint: disable=redefined-outer-name,invalid-name
+"""Тесты ручной (дословной) загрузки физ. результатов комиссии.
+
+Ключевой инвариант: при override `secondary_score` и агрегаты пишутся дословно
+и НЕ перетираются калькулятором (scoring.py), а обычный CRUD по-прежнему
+пересчитывает баллы автоматически.
+"""
+import pytest
+
+from ams.models.applicants import ApplicationProcess
+from ams.models.physical import ExerciseResult
+from ams.physical.exercises import ExerciseType
+from ams.utils.export.comp_sel_protocol import _format_exercise_value
+
+OVERRIDE_URL = "/api/ams/applicants/{pk}/exercise-results/override/"
+
+
+# ---------------------------------------------------------------------------
+# Уровень модели: механизм _skip_recalc
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestRecalcBypass:
+    def test_normal_save_recalculates(self, application_process):
+        """Обычное сохранение пересчитывает балл из value (строгий scoring)."""
+        er = ExerciseResult.objects.create(
+            application_process=application_process,
+            exercise_type=ExerciseType.SPEED_RUN_60M,
+            value=8.33,
+        )
+        er.refresh_from_db()
+        application_process.refresh_from_db()
+        # 8.33 по строгой логике DAL -> 87
+        assert er.secondary_score == 87
+        assert application_process.speed_score == 87
+
+    def test_skip_recalc_keeps_verbatim_score(self, application_process):
+        """С _skip_recalc дословный secondary_score не перетирается."""
+        er = ExerciseResult(
+            application_process=application_process,
+            exercise_type=ExerciseType.SPEED_RUN_60M,
+            value=8.33,
+            secondary_score=90,
+        )
+        er._skip_recalc = True
+        er.save()
+        er.refresh_from_db()
+        application_process.refresh_from_db()
+        assert er.secondary_score == 90  # НЕ 87
+        # агрегаты сохранения не трогает
+        assert application_process.speed_score == 0
+
+    def test_skip_recalc_on_delete(self, application_process):
+        """Удаление с _skip_recalc не запускает пересчёт агрегатов."""
+        er = ExerciseResult(
+            application_process=application_process,
+            exercise_type=ExerciseType.SPEED_RUN_60M,
+            value=8.3,
+            secondary_score=90,
+        )
+        er._skip_recalc = True
+        er.save()
+
+        application_process.speed_score = 55  # sentinel
+        application_process.save(update_fields=["speed_score"])
+
+        er._skip_recalc = True
+        er.delete()
+
+        application_process.refresh_from_db()
+        assert application_process.speed_score == 55  # не пересчитан в 0
+
+    def test_normal_delete_recalculates(self, application_process):
+        """Обычное удаление пересчитывает агрегаты."""
+        er = ExerciseResult.objects.create(
+            application_process=application_process,
+            exercise_type=ExerciseType.SPEED_RUN_60M,
+            value=8.3,
+        )
+        application_process.refresh_from_db()
+        assert application_process.speed_score == 90
+
+        er.delete()  # без _skip_recalc
+        application_process.refresh_from_db()
+        assert application_process.speed_score == 0
+
+
+# ---------------------------------------------------------------------------
+# Форматирование результата в протоколе (мм:сс для длинных дистанций)
+# ---------------------------------------------------------------------------
+
+
+def test_format_value_mmss_for_long_runs():
+    assert _format_exercise_value(3.85, ExerciseType.LONG_RUN_1KM) == "3:51"
+    assert _format_exercise_value(12.5, ExerciseType.LONG_RUN_3KM) == "12:30"
+    # спринт — как есть, десятичные секунды
+    assert _format_exercise_value(8.33, ExerciseType.SPEED_RUN_60M) == 8.33
+    # счётные — целое
+    assert _format_exercise_value(21.0, ExerciseType.PULL_UPS) == 21
+
+
+# ---------------------------------------------------------------------------
+# Эндпоинт override
+# ---------------------------------------------------------------------------
+
+OVERRIDE_BODY = {
+    "results": [
+        {"exercise_type": "PULL_UPS", "value": 21, "secondary_score": 83},
+        {"exercise_type": "RUN_60", "value": 8.33, "secondary_score": 90},
+        {"exercise_type": "RUN_1K", "value": 3.85, "secondary_score": 39},
+    ],
+    "strength_score": 83,
+    "speed_score": 90,
+    "endurance_score": 39,
+    "physical_test_grade": 100,
+}
+
+
+@pytest.mark.django_db
+def test_override_endpoint_stores_verbatim(su_client, applicant):
+    resp = su_client.post(
+        OVERRIDE_URL.format(pk=applicant.id),
+        OVERRIDE_BODY,
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+
+    ap = applicant.application_process
+    ap.refresh_from_db()
+    assert ap.physical_test_grade == 100
+    assert (ap.strength_score, ap.speed_score, ap.endurance_score) == (83, 90, 39)
+
+    results = {e.exercise_type: e for e in ap.exercise_results.all()}
+    # RUN_60: балл дословный (90), НЕ строгий scoring (87)
+    assert results["RUN_60"].secondary_score == 90
+    assert results["RUN_60"].value == 8.33
+    assert results["RUN_1K"].secondary_score == 39
+
+
+@pytest.mark.django_db
+def test_override_replaces_stale_results(su_client, applicant):
+    ap = applicant.application_process
+    # заранее кладём «старое» упражнение, которого нет в новом наборе
+    stale = ExerciseResult(
+        application_process=ap,
+        exercise_type=ExerciseType.LONG_RUN_3KM,
+        value=13.0,
+        secondary_score=55,
+    )
+    stale._skip_recalc = True
+    stale.save()
+
+    resp = su_client.post(
+        OVERRIDE_URL.format(pk=applicant.id),
+        OVERRIDE_BODY,
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+
+    types = set(
+        ap.exercise_results.values_list("exercise_type", flat=True)
+    )
+    assert types == {"PULL_UPS", "RUN_60", "RUN_1K"}  # RUN_3K удалён
+
+
+@pytest.mark.django_db
+def test_override_forbidden_without_permission(test_client, applicant):
+    resp = test_client.post(
+        OVERRIDE_URL.format(pk=applicant.id),
+        OVERRIDE_BODY,
+        content_type="application/json",
+    )
+    assert resp.status_code == 403

--- a/back-end/src/ams/urls.py
+++ b/back-end/src/ams/urls.py
@@ -25,6 +25,11 @@ exercise_results_detail = ExerciseResultViewSet.as_view(
         "delete": "destroy",
     }
 )
+exercise_results_override = ExerciseResultViewSet.as_view(
+    {
+        "post": "override",
+    }
+)
 
 urlpatterns = [
     # Router.
@@ -41,6 +46,13 @@ urlpatterns = [
         "applicants/<int:applicant_pk>/exercise-results/",
         exercise_results_list,
         name="exercise-results-list",
+    ),
+    # Ручная (дословная) загрузка результатов комиссии — до detail-роута,
+    # чтобы "override" не был распознан как exercise_type.
+    path(
+        "applicants/<int:applicant_pk>/exercise-results/override/",
+        exercise_results_override,
+        name="exercise-results-override",
     ),
     path(
         "applicants/<int:applicant_pk>/exercise-results/<str:exercise_type>/",

--- a/back-end/src/ams/utils/export/comp_sel_protocol.py
+++ b/back-end/src/ams/utils/export/comp_sel_protocol.py
@@ -358,7 +358,9 @@ def _make_applicant_row(
             row += [("", formats.table_center)] * 3
             continue
 
-        result_value = _format_exercise_value(exercise["value"])
+        result_value = _format_exercise_value(
+            exercise["value"], exercise.get("exercise_type")
+        )
         row += [
             (exercise["number"], formats.table_center),
             (result_value, formats.table_center),
@@ -420,14 +422,23 @@ def _select_best_exercises(application_process, registry: dict) -> dict:
                 "number": EXERCISE_NUMBERS.get(result.exercise_type, ""),
                 "value": result.value,
                 "score": result.secondary_score,
+                "exercise_type": result.exercise_type,
             }
 
     return best
 
 
-def _format_exercise_value(value):
+# Беговые упражнения на длинные дистанции хранятся в десятичных минутах,
+# но в протоколе показываются как мин:сек (3.85 -> "3:51").
+_MMSS_EXERCISES = {ExerciseType.LONG_RUN_1KM, ExerciseType.LONG_RUN_3KM}
+
+
+def _format_exercise_value(value, exercise_type=None):
     if value is None:
         return ""
+    if exercise_type in _MMSS_EXERCISES and isinstance(value, (int, float)):
+        total_seconds = round(value * 60)
+        return f"{total_seconds // 60}:{total_seconds % 60:02d}"
     if isinstance(value, float) and value.is_integer():
         return int(value)
     return round(value, 2) if isinstance(value, float) else value

--- a/back-end/src/ams/views/physical.py
+++ b/back-end/src/ams/views/physical.py
@@ -1,5 +1,8 @@
 from auth.permissions import BasePermission, Permission
+from django.db import transaction
 from drf_spectacular.views import extend_schema
+from rest_framework import status
+from rest_framework.decorators import action
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -11,6 +14,7 @@ from ams.physical.exercises import get_exercise_registry
 from ams.serializers.physical import (
     ExerciseDefinitionSerializer,
     ExerciseResultSerializer,
+    PhysicalOverrideSerializer,
 )
 
 
@@ -19,6 +23,14 @@ class ExerciseResultPermission(BasePermission):
     view_name_rus = "Результаты упражнений"
     methods = ["get", "post", "patch", "delete"]
     scopes = [Permission.Scope.ALL, Permission.Scope.SELF]
+
+
+class ExerciseResultOverridePermission(BasePermission):
+    permission_class = "exercise_results_override"
+    view_name_rus = "Ручной ввод результатов упражнений"
+    methods = ["post"]
+    # Только ALL: абитуриент не может задать себе балл комиссии дословно.
+    scopes = [Permission.Scope.ALL]
 
 
 @extend_schema(tags=["physical"])
@@ -65,3 +77,64 @@ class ExerciseResultViewSet(ModelViewSet):
     def perform_destroy(self, instance):
         instance.delete()
         # Пересчет происходит автоматически в post_delete сигнале
+
+    @extend_schema(request=PhysicalOverrideSerializer, responses={200: None})
+    @action(
+        detail=False,
+        methods=["post"],
+        url_path="override",
+        permission_classes=[ExerciseResultOverridePermission],
+    )
+    def override(self, request: Request, applicant_pk=None) -> Response:
+        """Дословная загрузка физ. результатов комиссии БЕЗ пересчёта баллов.
+
+        Полностью заменяет набор результатов абитуриента: `value` и
+        `secondary_score` пишутся как есть, агрегаты выставляются напрямую.
+        Идемпотентно — повторный POST с тем же телом даёт то же состояние.
+        """
+        # pylint: disable=unused-argument
+        serializer = PhysicalOverrideSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+
+        ap = self._get_application_process()
+        incoming = {item["exercise_type"]: item for item in data["results"]}
+
+        with transaction.atomic():
+            # Удаляем устаревшие результаты (пересчёт подавляем).
+            for stale in ap.exercise_results.exclude(
+                exercise_type__in=incoming.keys()
+            ):
+                stale._skip_recalc = True
+                stale.delete()
+
+            # Апсертим переданные — дословно, без пересчёта.
+            # ВАЖНО: `_skip_recalc` ставим ДО первого save() (в т.ч. на создании),
+            # иначе пересчёт при вставке затрёт secondary_score других упражнений.
+            for etype, item in incoming.items():
+                obj = ap.exercise_results.filter(exercise_type=etype).first()
+                if obj is None:
+                    obj = ExerciseResult(
+                        application_process=ap, exercise_type=etype
+                    )
+                obj.value = item["value"]
+                obj.secondary_score = item["secondary_score"]
+                obj.extra_params = item.get("extra_params", {})
+                obj._skip_recalc = True
+                obj.save()
+
+            # Агрегаты — напрямую.
+            ap.strength_score = data["strength_score"]
+            ap.speed_score = data["speed_score"]
+            ap.endurance_score = data["endurance_score"]
+            ap.physical_test_grade = data["physical_test_grade"]
+            ap.save(
+                update_fields=[
+                    "strength_score",
+                    "speed_score",
+                    "endurance_score",
+                    "physical_test_grade",
+                ]
+            )
+
+        return Response(status=status.HTTP_200_OK)

--- a/back-end/src/ams/views/physical.py
+++ b/back-end/src/ams/views/physical.py
@@ -102,9 +102,7 @@ class ExerciseResultViewSet(ModelViewSet):
 
         with transaction.atomic():
             # Удаляем устаревшие результаты (пересчёт подавляем).
-            for stale in ap.exercise_results.exclude(
-                exercise_type__in=incoming.keys()
-            ):
+            for stale in ap.exercise_results.exclude(exercise_type__in=incoming.keys()):
                 stale._skip_recalc = True
                 stale.delete()
 
@@ -114,9 +112,7 @@ class ExerciseResultViewSet(ModelViewSet):
             for etype, item in incoming.items():
                 obj = ap.exercise_results.filter(exercise_type=etype).first()
                 if obj is None:
-                    obj = ExerciseResult(
-                        application_process=ap, exercise_type=etype
-                    )
+                    obj = ExerciseResult(application_process=ap, exercise_type=etype)
                 obj.value = item["value"]
                 obj.secondary_score = item["secondary_score"]
                 obj.extra_params = item.get("extra_params", {})

--- a/tools/dal-fill/analyze_scoring.py
+++ b/tools/dal-fill/analyze_scoring.py
@@ -1,0 +1,293 @@
+"""
+Сверка логики подсчёта баллов ФИЗО между:
+  (A) DAL scoring.py  — strict (value <= threshold, без округления)
+  (B) DAL scoring.py  — с округлением беговых результатов до 0.1 сек
+  (C) ведомость 2026 "Результаты ФИЗО" — уже посчитанные баллы (столбцы «О», итог100)
+
+Цель: понять корень расхождения и его масштаб по всем ~955 участникам.
+
+Запуск:  python3 tools/dal-fill/analyze_scoring.py
+"""
+import math
+import sys
+from pathlib import Path
+
+import openpyxl
+
+# --- импорт настоящего scoring.py из back-end (чистый модуль, без Django) ---
+PHYS = Path(__file__).resolve().parents[2] / "back-end" / "src" / "ams" / "physical"
+sys.path.insert(0, str(PHYS))
+import scoring  # noqa: E402
+
+DATA = Path.home() / "Downloads" / "dal-fill-db"
+FIZO = DATA / "Результаты ФИЗО нормативы16.06.26-2 (2).xlsx"
+
+# Колонки 2026 "Результаты" (1-based): (result_col, dal_convert, direction, number, kind)
+# kind: 'int' счётное, 'sec' секунды(бег кор.), 'mmss' мин.сек(бег длин.), 'kettle' гиря
+STRENGTH, SPEED, ENDUR = "ST", "SP", "EN"
+EXODEF = [
+    # подтягивание №3
+    ("PULL_UPS", 12, 13, scoring.convert_pull_ups, STRENGTH, 3, "int"),
+    # подъём переворотом №5
+    ("LIFT_TURNOVER", 14, 15, scoring.convert_lift_turnover, STRENGTH, 5, "int"),
+    # подъём силой №6
+    ("LIFT_FORCE", 16, 17, scoring.convert_lift_force, STRENGTH, 6, "int"),
+    # рывок гири №10 — результат в R/S/T (70/80/80+), балл в U(21)
+    ("KETTLEBELL_SNATCH", None, 21, scoring.convert_kettlebell_snatch, STRENGTH, 10, "kettle"),
+    # бег 60м №17
+    ("RUN_60", 23, 24, scoring.convert_run_60m, SPEED, 17, "sec"),
+    # бег 100м №18
+    ("RUN_100", 25, 26, scoring.convert_run_100m, SPEED, 18, "sec"),
+    # челночный 10x10 №19
+    ("SHUTTLE_RUN", 27, 28, scoring.convert_shuttle_run, SPEED, 19, "sec"),
+    # бег 1км №24
+    ("RUN_1K", 30, 31, scoring.convert_run_1km, ENDUR, 24, "mmss"),
+    # бег 3км №25
+    ("RUN_3K", 32, 33, scoring.convert_run_3km, ENDUR, 25, "mmss"),
+]
+# столбцы гири по весовым категориям (result → вес для DAL)
+KETTLE_COLS = {18: 65, 19: 75, 20: 85}  # R=<70(light), S=70-80(medium), T=>80(heavy)
+
+COL_SILA_O, COL_BYSTR_O, COL_VYNOS_O = 22, 29, 34
+COL_ITOG, COL_OC5, COL_ITOG100 = 35, 36, 37
+
+
+def round_01(x):
+    """Округление до 0.1 (half-up) — как в формулах ведомости."""
+    return math.floor(x * 10 + 0.5) / 10.0
+
+
+def mmss_to_decmin(v):
+    """3.51 (3 мин 51 сек) -> 3.85 десятичных минут."""
+    minutes = int(v)
+    seconds = round((v - minutes) * 100)  # .51 -> 51 сек
+    return minutes + seconds / 60.0
+
+
+def age_of(bd):
+    from datetime import date
+    today = date(2026, 7, 2)
+    return today.year - bd.year - ((today.month, today.day) < (bd.month, bd.day))
+
+
+def num(v):
+    if v in (None, ""):
+        return 0
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0
+
+
+def main():
+    wb = openpyxl.load_workbook(FIZO, data_only=True)
+    ws = wb["до 25"]
+
+    rows = []
+    for r in range(15, 970):
+        name = ws.cell(r, 2).value
+        if not name:
+            continue
+        bd = ws.cell(r, 3).value
+        rows.append((r, name, bd))
+
+    # счётчики
+    n = 0
+    per_ex_strict_mismatch = {d[0]: 0 for d in EXODEF}
+    per_ex_round_mismatch = {d[0]: 0 for d in EXODEF}
+    per_ex_present = {d[0]: 0 for d in EXODEF}
+    grade_strict_mismatch = 0
+    grade_round_mismatch = 0
+    examples_strict = []
+    examples_round = []
+
+    for (r, name, bd) in rows:
+        n += 1
+        age = age_of(bd) if bd else 19
+        dir_scores_strict = {STRENGTH: [], SPEED: [], ENDUR: []}
+        dir_scores_round = {STRENGTH: [], SPEED: [], ENDUR: []}
+
+        for (etype, rcol, ocol, conv, direction, number, kind) in EXODEF:
+            # получить сырой результат и балл ведомости
+            ved_o = num(ws.cell(r, ocol).value)
+            if kind == "kettle":
+                val = None
+                weight = None
+                for kcol, w in KETTLE_COLS.items():
+                    cv = num(ws.cell(r, kcol).value)
+                    if cv > 0:
+                        val, weight = cv, w
+                        break
+                if val is None:
+                    continue
+                per_ex_present[etype] += 1
+                s_strict = conv(val, {"weight": weight}, age)
+                s_round = s_strict  # счётное, округление не нужно
+            else:
+                raw = num(ws.cell(r, rcol).value)
+                if raw <= 0:
+                    continue
+                per_ex_present[etype] += 1
+                if kind == "mmss":
+                    dv = mmss_to_decmin(raw)
+                    s_strict = conv(dv, {}, age)
+                    s_round = conv(dv, {}, age)  # секунды точны -> без округл.
+                elif kind == "sec":
+                    s_strict = conv(raw, {}, age)
+                    s_round = conv(round_01(raw), {}, age)
+                else:  # int
+                    s_strict = conv(int(raw), {}, age)
+                    s_round = s_strict
+
+            if s_strict != ved_o:
+                per_ex_strict_mismatch[etype] += 1
+                if len(examples_strict) < 25:
+                    examples_strict.append(
+                        (name, etype, ws.cell(r, rcol).value if rcol else "kettle",
+                         f"DAL={s_strict}", f"вед={ved_o}"))
+            if s_round != ved_o:
+                per_ex_round_mismatch[etype] += 1
+                if len(examples_round) < 25:
+                    examples_round.append(
+                        (name, etype, ws.cell(r, rcol).value if rcol else "kettle",
+                         f"DALr={s_round}", f"вед={ved_o}"))
+
+            dir_scores_strict[direction].append(s_strict)
+            dir_scores_round[direction].append(s_round)
+
+        # итоговый балл (100-балльный global)
+        def grade(dsc):
+            st = max(dsc[STRENGTH]) if dsc[STRENGTH] else 0
+            sp = max(dsc[SPEED]) if dsc[SPEED] else 0
+            en = max(dsc[ENDUR]) if dsc[ENDUR] else 0
+            return scoring.compute_global_score(st, sp, en, age)
+
+        g_strict = grade(dir_scores_strict)
+        g_round = grade(dir_scores_round)
+        ved_grade = int(num(ws.cell(r, COL_ITOG100).value))
+
+        if g_strict != ved_grade:
+            grade_strict_mismatch += 1
+        if g_round != ved_grade:
+            grade_round_mismatch += 1
+
+    print(f"Всего участников: {n}\n")
+    print("Наличие результатов по упражнениям:")
+    for d in EXODEF:
+        print(f"  {d[0]:16s} present={per_ex_present[d[0]]:4d}")
+    print("\nРасхождения ПОБАЛЛЬНО (secondary score) DAL vs ведомость:")
+    print(f"  {'упражнение':16s} {'strict':>8s} {'round0.1':>9s}")
+    for d in EXODEF:
+        print(f"  {d[0]:16s} {per_ex_strict_mismatch[d[0]]:8d} {per_ex_round_mismatch[d[0]]:9d}")
+    print("\nРасхождения ИТОГОВОГО балла (100-балльн.) vs ведомость (столбец итог100):")
+    print(f"  strict  : {grade_strict_mismatch} / {n}")
+    print(f"  round0.1: {grade_round_mismatch} / {n}")
+
+    print("\nПримеры расхождений STRICT (первые):")
+    for e in examples_strict[:15]:
+        print("   ", e)
+    print("\nПримеры расхождений ROUND0.1 (первые):")
+    for e in examples_round[:15]:
+        print("   ", e)
+
+
+if __name__ == "__main__":
+    main()
+
+
+# ============================================================================
+# ДОП. ВЕРИФИКАЦИЯ: (1) таблицы DAL == сетка комиссии; (2) grade по О комиссии
+# == итог100 комиссии; (3) «примагничивание» value к сетке -> DAL == комиссия.
+# ============================================================================
+
+def verify_gridsnap():
+    import openpyxl as _oxl
+    wb = _oxl.load_workbook(FIZO, data_only=True)
+    ws = wb["до 25"]
+
+    # инверсия: для «меньше-лучше» вернуть порог-сетку, дающий score S под DAL.
+    def invert_time(table, S):
+        # table: [(threshold_time, score)] возрастающее время / убывающий балл
+        cands = [t for (t, sc) in table if sc == S]
+        return max(cands) if cands else None
+
+    TIME_TABLES = {
+        "RUN_60": scoring._RUN_60M_TABLE,
+        "RUN_100": scoring._RUN_100M_TABLE,
+        "SHUTTLE_RUN": scoring._SHUTTLE_RUN_TABLE,
+        "RUN_1K": scoring._RUN_1KM_TABLE,
+        "RUN_3K": scoring._RUN_3KM_TABLE,
+    }
+
+    n = 0
+    grade_by_comm_o_mismatch = 0     # grade из О комиссии vs итог100 комиссии
+    grade_snap_mismatch = 0          # grade из snapped-value(DAL) vs итог100 комиссии
+    unreproducible = []              # О комиссии не выражается порогом DAL
+    o_table_mismatch = []            # О комиссии не совпадает с DAL(snap)
+
+    for r in range(15, 970):
+        name = ws.cell(r, 2).value
+        if not name:
+            continue
+        bd = ws.cell(r, 3).value
+        age = age_of(bd) if bd else 19
+        n += 1
+
+        comm_dir = {STRENGTH: [], SPEED: [], ENDUR: []}
+        snap_dir = {STRENGTH: [], SPEED: [], ENDUR: []}
+
+        for (etype, rcol, ocol, conv, direction, number, kind) in EXODEF:
+            comm_o = int(num(ws.cell(r, ocol).value))
+            if kind == "kettle":
+                present = any(num(ws.cell(r, c).value) > 0 for c in KETTLE_COLS)
+                if not present:
+                    continue
+                # для гири храним сырое: DAL уже совпал 100%
+                snap_o = comm_o
+            else:
+                raw = num(ws.cell(r, rcol).value)
+                if raw <= 0:
+                    continue
+                if kind == "int":
+                    snap_o = comm_o  # счётные совпали 100%
+                else:
+                    tbl = TIME_TABLES[etype]
+                    snap_val = invert_time(tbl, comm_o)
+                    if snap_val is None:
+                        unreproducible.append((name, etype, comm_o))
+                        snap_o = None
+                    else:
+                        snap_o = conv(snap_val, {}, age)
+                        if snap_o != comm_o:
+                            o_table_mismatch.append((name, etype, comm_o, snap_o))
+            if snap_o is not None:
+                snap_dir[direction].append(snap_o)
+            comm_dir[direction].append(comm_o)
+
+        def g(dsc):
+            st = max(dsc[STRENGTH]) if dsc[STRENGTH] else 0
+            sp = max(dsc[SPEED]) if dsc[SPEED] else 0
+            en = max(dsc[ENDUR]) if dsc[ENDUR] else 0
+            return scoring.compute_global_score(st, sp, en, age)
+
+        ved_grade = int(num(ws.cell(r, COL_ITOG100).value))
+        if g(comm_dir) != ved_grade:
+            grade_by_comm_o_mismatch += 1
+        if g(snap_dir) != ved_grade:
+            grade_snap_mismatch += 1
+
+    print("\n" + "=" * 70)
+    print("ВЕРИФИКАЦИЯ GRID-SNAP (хранить значение, примагниченное к сетке):")
+    print(f"  участников: {n}")
+    print(f"  grade(из О комиссии)      != итог100 комиссии : {grade_by_comm_o_mismatch}")
+    print(f"  grade(DAL по snapped val) != итог100 комиссии : {grade_snap_mismatch}")
+    print(f"  О комиссии невыразимо порогом DAL : {len(unreproducible)}")
+    if unreproducible[:10]:
+        print("    примеры:", unreproducible[:10])
+    print(f"  DAL(snap) != О комиссии (таблицы расходятся) : {len(o_table_mismatch)}")
+    if o_table_mismatch[:10]:
+        print("    примеры:", o_table_mismatch[:10])
+
+
+if __name__ == "__main__":
+    verify_gridsnap()

--- a/tools/dal-fill/core.py
+++ b/tools/dal-fill/core.py
@@ -1,0 +1,655 @@
+"""
+core.py — единый общий модуль для ДВУХ путей заполнения "Протокола конкурсного
+отбора" физическими результатами (ФИЗО) и средним баллом:
+
+  * Вариант 1 (ручной): пишем значения прямо в копии существующих xlsx-протоколов.
+  * Вариант 2 (prod):    пушим сырые значения в prod-API DAL, DAL сам пересчитывает
+                          и заново экспортирует протокол.
+
+Оба варианта импортируют ЭТОТ модуль и берут из него ОДНИ И ТЕ ЖЕ числа
+(value_to_store, score, physical_test_grade, mean_grade_scaled, final_result),
+поэтому итоговые протоколы обязаны совпасть побайтно по значениям.
+
+Проверенная логика (из tools/dal-fill/analyze_scoring.py) переиспользуется здесь
+без изменений: карта колонок упражнений (EXODEF), mmss_to_decmin(), round_01(),
+трюк импорта настоящего scoring.py и инверсия «примагничивания» к сетке
+(invert_time). Прогон analyze_scoring доказал: если хранить примагниченное к
+сетке значение, DAL воспроизводит баллы комиссии (0/955 расхождений).
+
+Зеркалит back-end/src/ams/utils/export/comp_sel_protocol.py:
+  _select_best_exercises (лучшее в направлении = MAX score), EXERCISE_NUMBERS,
+  _format_exercise_value, _get_age_group.
+Опорная дата возраста — 2026-07-02.
+
+Запуск:  python3 tools/dal-fill/core.py
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+import unicodedata
+from datetime import date, datetime
+from pathlib import Path
+
+import openpyxl
+
+# ---------------------------------------------------------------------------
+# Импорт настоящего scoring.py из back-end (чистый модуль, без Django deps)
+# ---------------------------------------------------------------------------
+PHYS = Path(__file__).resolve().parents[2] / "back-end" / "src" / "ams" / "physical"
+sys.path.insert(0, str(PHYS))
+import scoring  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Режим подсчёта
+#   'verbatim' (по умолчанию): храним СЫРОЙ результат комиссии (спринт 8.33,
+#       длинные — в десятичных минутах 3.85 = 3:51) и ДОСЛОВНЫЙ балл комиссии О.
+#       Заливается через ручку override (secondary_score пишется как есть, без
+#       пересчёта). В протоколе — сырой результат + мм:сс + балл комиссии.
+#   'committee': примагничиваем время к сетке DAL так, чтобы DAL сам пересчитал
+#       и воспроизвёл подписанный балл О (0/955 расхождений). Обычные ручки.
+#   'strict': храним сырые значения, DAL считает строго value <= threshold.
+# ---------------------------------------------------------------------------
+SCORING_MODE = "verbatim"
+
+# Беговые длинные дистанции показываются в протоколе как мин:сек (зеркало
+# back-end/src/ams/utils/export/comp_sel_protocol._MMSS_EXERCISES).
+_MMSS_EXERCISES = {"RUN_1K", "RUN_3K"}
+
+# ---------------------------------------------------------------------------
+# Пути к источникам
+# ---------------------------------------------------------------------------
+DATA = Path.home() / "Downloads" / "dal-fill-db"
+FIZO_PATH = DATA / "Результаты ФИЗО нормативы16.06.26-2 (2).xlsx"
+FIZO_SHEET = "до 25"
+FIZO_ROW_START = 15
+FIZO_ROW_END = 969  # включительно
+FIZO_NAME_COL = 2
+FIZO_DOB_COL = 3
+
+GRADE_PATH = DATA / "Средний балл.xlsx"
+GRADE_SHEET = "Лист2"
+GRADE_NAME_COL = 1  # A = ФИО
+GRADE_DOB_COL = 2   # B = дата рождения
+GRADE_MEAN_COL = 5  # E = средний балл 0..10
+
+# Опорная дата для расчёта возраста (совпадает с текущей датой протокола).
+AGE_REF_DATE = date(2026, 7, 2)
+
+# ---------------------------------------------------------------------------
+# Направления (значения совпадают с Direction.* из ams.physical.exercises)
+# ---------------------------------------------------------------------------
+STRENGTH = "ST"
+SPEED = "SP"
+ENDURANCE = "EN"
+
+# ---------------------------------------------------------------------------
+# Определение упражнений (переиспользуем проверенную карту из analyze_scoring).
+# Формат: (exercise_type, result_col, score_col, convert_fn, direction, number, kind)
+#   result_col — 1-based колонка сырого результата (None для гири — особый разбор)
+#   score_col  — 1-based колонка балла «О», подписанного комиссией
+#   number     — номер упражнения в протоколе (EXERCISE_NUMBERS)
+#   kind       — 'int' счётное | 'sec' секунды (короткий бег) |
+#                'mmss' мин.сек (длинный бег) | 'kettle' гиря
+# exercise_type здесь — это ExerciseType.value (то, что хранит DAL).
+# ---------------------------------------------------------------------------
+EXODEF = [
+    ("PULL_UPS", 12, 13, scoring.convert_pull_ups, STRENGTH, 3, "int"),
+    ("LIFT_TURNOVER", 14, 15, scoring.convert_lift_turnover, STRENGTH, 5, "int"),
+    ("LIFT_FORCE", 16, 17, scoring.convert_lift_force, STRENGTH, 6, "int"),
+    ("KETTLEBELL_SNATCH", None, 21, scoring.convert_kettlebell_snatch, STRENGTH, 10, "kettle"),
+    ("RUN_60", 23, 24, scoring.convert_run_60m, SPEED, 17, "sec"),
+    ("RUN_100", 25, 26, scoring.convert_run_100m, SPEED, 18, "sec"),
+    ("SHUTTLE_RUN", 27, 28, scoring.convert_shuttle_run, SPEED, 19, "sec"),
+    ("RUN_1K", 30, 31, scoring.convert_run_1km, ENDURANCE, 24, "mmss"),
+    ("RUN_3K", 32, 33, scoring.convert_run_3km, ENDURANCE, 25, "mmss"),
+]
+
+# Колонки гири по весовым категориям (result_col -> вес атлета для DAL).
+#   R(18) — до 70 кг (light, weight=65)
+#   S(19) — 70-80 кг (medium, weight=75)
+#   T(20) — более 80 кг (heavy, weight=85)
+KETTLE_COLS = {18: 65, 19: 75, 20: 85}
+
+# Агрегатные колонки, подписанные комиссией (1-based), для verbatim-режима:
+#   СИЛА-О=22, БЫСТР-О=29, ВЫНОС-О=34, итог по 100-балльной=37.
+COL_STRENGTH_O = 22
+COL_SPEED_O = 29
+COL_ENDURANCE_O = 34
+COL_ITOG100 = 37
+
+# Номер упражнения в протоколе — из comp_sel_protocol.EXERCISE_NUMBERS
+# (уже зашит в EXODEF полем number, дублируем как справочник по exercise_type).
+EXERCISE_NUMBERS = {d[0]: d[5] for d in EXODEF}
+
+# Таблицы «меньше — лучше» для инверсии примагничивания к сетке.
+TIME_TABLES = {
+    "RUN_60": scoring._RUN_60M_TABLE,
+    "RUN_100": scoring._RUN_100M_TABLE,
+    "SHUTTLE_RUN": scoring._SHUTTLE_RUN_TABLE,
+    "RUN_1K": scoring._RUN_1KM_TABLE,
+    "RUN_3K": scoring._RUN_3KM_TABLE,
+}
+
+
+# ===========================================================================
+# Числовые/строковые хелперы (переиспользованы из analyze_scoring.py)
+# ===========================================================================
+def round_01(x: float) -> float:
+    """Округление до 0.1 (half-up) — как в формулах ведомости."""
+    return math.floor(x * 10 + 0.5) / 10.0
+
+
+def mmss_to_decmin(v: float) -> float:
+    """3.51 (3 мин 51 сек) -> 3.85 десятичных минут (то, что ждёт DAL)."""
+    minutes = int(v)
+    seconds = round((v - minutes) * 100)  # .51 -> 51 сек
+    return minutes + seconds / 60.0
+
+
+def invert_time(table, target_score: int):
+    """Для «меньше-лучше» вернуть максимальный порог сетки, дающий target_score
+    под DAL (value <= threshold). Так DAL воспроизведёт балл О комиссии.
+
+    table: [(threshold_time, score)] — время возрастает, балл убывает.
+    """
+    cands = [t for (t, sc) in table if sc == target_score]
+    return max(cands) if cands else None
+
+
+def _age_of(bd: date) -> int:
+    """Полных лет на опорную дату AGE_REF_DATE."""
+    return (
+        AGE_REF_DATE.year
+        - bd.year
+        - ((AGE_REF_DATE.month, AGE_REF_DATE.day) < (bd.month, bd.day))
+    )
+
+
+def _num(v):
+    """Толерантное приведение ячейки к float; пусто/мусор -> 0."""
+    if v in (None, ""):
+        return 0
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0
+
+
+# ===========================================================================
+# Нормализация ключей сопоставления (name, dob)
+# ===========================================================================
+def norm_name(s) -> str:
+    """NFC, ё->е, схлопнуть пробелы, casefold."""
+    if s is None:
+        return ""
+    s = unicodedata.normalize("NFC", str(s))
+    s = s.replace("ё", "е").replace("Ё", "Е")
+    s = " ".join(s.split())
+    return s.casefold()
+
+
+def norm_dob(v) -> str:
+    """Нормализовать дату рождения к 'dd.mm.yyyy'.
+
+    Принимает datetime/date, а также строки в формах dd.mm.yyyy / yyyy-mm-dd
+    / dd/mm/yyyy. Пусто/непонятно -> ''.
+    """
+    if v is None or v == "":
+        return ""
+    if isinstance(v, datetime):
+        return v.strftime("%d.%m.%Y")
+    if isinstance(v, date):
+        return v.strftime("%d.%m.%Y")
+    s = str(v).strip()
+    if not s:
+        return ""
+    # Отрезать возможную временную часть.
+    s = s.split(" ")[0].split("T")[0]
+    for sep in (".", "-", "/"):
+        if sep in s:
+            parts = s.split(sep)
+            if len(parts) == 3:
+                a, b, c = parts
+                # yyyy-mm-dd
+                if len(a) == 4:
+                    y, m, d = a, b, c
+                else:  # dd.mm.yyyy / dd/mm/yyyy
+                    d, m, y = a, b, c
+                try:
+                    return f"{int(d):02d}.{int(m):02d}.{int(y):04d}"
+                except ValueError:
+                    return s
+    return s
+
+
+def _key(name, dob) -> tuple[str, str]:
+    return (norm_name(name), norm_dob(dob))
+
+
+# ===========================================================================
+# Загрузчики: строят индексы по нормализованному (name, dob) + name-only fallback
+# ===========================================================================
+class FizoIndex:
+    """Индекс результатов ФИЗО.
+
+    by_key      : (norm_name, norm_dob) -> record
+    by_name     : norm_name -> [record, ...]   (для уникального fallback по имени)
+    records     : список всех record (для отчётов о непопавших)
+
+    record = {
+        "name": str, "dob_raw": <cell>, "dob": "dd.mm.yyyy",
+        "age": int, "row": int,
+        "raw": {exercise_type: (result_col_value | ('kettle', reps, weight))},
+    }
+    """
+
+    def __init__(self):
+        self.by_key: dict[tuple[str, str], dict] = {}
+        self.by_name: dict[str, list[dict]] = {}
+        self.records: list[dict] = []
+
+    def add(self, rec: dict) -> None:
+        self.records.append(rec)
+        self.by_key[_key(rec["name"], rec["dob_raw"])] = rec
+        self.by_name.setdefault(norm_name(rec["name"]), []).append(rec)
+
+    def lookup(self, name, dob):
+        """Вернуть (record, match_kind) или (None, None).
+
+        match_kind: 'key' (name+dob) | 'name' (уникальный name-only fallback).
+        """
+        rec = self.by_key.get(_key(name, dob))
+        if rec is not None:
+            return rec, "key"
+        cands = self.by_name.get(norm_name(name), [])
+        if len(cands) == 1:
+            return cands[0], "name"
+        return None, None
+
+
+def load_fizo(path: Path = FIZO_PATH) -> FizoIndex:
+    """Загрузить ФИЗО в индекс (единственный канонический загрузчик).
+
+    Читает по каждому упражнению И сырой результат (rec["raw"][etype]), И
+    подписанный комиссией балл О (rec["committee_o"][etype]) — последний нужен
+    committee-режиму для инверсии примагничивания к сетке.
+
+    Кампусный охват: в ведомости только Москва + ВАВТ (нет СПб/НН/Перми) —
+    фильтрацию по кампусу делает вызывающий, здесь индексируем всех со строкой.
+    """
+    wb = openpyxl.load_workbook(path, data_only=True)
+    ws = wb[FIZO_SHEET]
+
+    index = FizoIndex()
+    for r in range(FIZO_ROW_START, FIZO_ROW_END + 1):
+        name = ws.cell(r, FIZO_NAME_COL).value
+        if not name:
+            continue
+        dob_raw = ws.cell(r, FIZO_DOB_COL).value
+
+        raw: dict[str, object] = {}
+        committee_o: dict[str, int] = {}
+        for (etype, rcol, ocol, conv, direction, number, kind) in EXODEF:
+            committee_o[etype] = int(_num(ws.cell(r, ocol).value))
+            if kind == "kettle":
+                reps = None
+                weight = None
+                for kcol, w in KETTLE_COLS.items():
+                    cv = _num(ws.cell(r, kcol).value)
+                    if cv > 0:
+                        reps, weight = cv, w
+                        break
+                if reps is not None:
+                    raw[etype] = ("kettle", reps, weight)
+            else:
+                val = _num(ws.cell(r, rcol).value)
+                if val > 0:
+                    raw[etype] = val
+
+        rec = {
+            "name": str(name).strip(),
+            "dob_raw": dob_raw,
+            "dob": norm_dob(dob_raw),
+            "age": _age_of(dob_raw) if isinstance(dob_raw, (date, datetime)) else 19,
+            "row": r,
+            "raw": raw,
+            "committee_o": committee_o,
+            # Агрегаты, подписанные комиссией (verbatim-режим берёт их как есть).
+            "committee_agg": {
+                STRENGTH: int(_num(ws.cell(r, COL_STRENGTH_O).value)),
+                SPEED: int(_num(ws.cell(r, COL_SPEED_O).value)),
+                ENDURANCE: int(_num(ws.cell(r, COL_ENDURANCE_O).value)),
+                "physical_test_grade": int(_num(ws.cell(r, COL_ITOG100).value)),
+            },
+        }
+        index.add(rec)
+
+    return index
+
+
+class GradeIndex:
+    """Индекс среднего балла.
+
+    by_key  : (norm_name, norm_dob) -> mean_grade(float 0..10)
+    by_name : norm_name -> [mean_grade, ...]  (уникальный fallback)
+    """
+
+    def __init__(self):
+        self.by_key: dict[tuple[str, str], float] = {}
+        self.by_name: dict[str, list[float]] = {}
+        self.records: list[dict] = []
+
+    def add(self, name, dob_raw, mean_grade: float) -> None:
+        self.records.append(
+            {"name": str(name).strip(), "dob_raw": dob_raw,
+             "dob": norm_dob(dob_raw), "mean_grade": mean_grade}
+        )
+        self.by_key[_key(name, dob_raw)] = mean_grade
+        self.by_name.setdefault(norm_name(name), []).append(mean_grade)
+
+    def lookup(self, name, dob):
+        """Вернуть (mean_grade, match_kind) или (None, None)."""
+        mg = self.by_key.get(_key(name, dob))
+        if mg is not None:
+            return mg, "key"
+        cands = self.by_name.get(norm_name(name), [])
+        if len(cands) == 1:
+            return cands[0], "name"
+        return None, None
+
+
+def load_grades(path: Path = GRADE_PATH) -> GradeIndex:
+    wb = openpyxl.load_workbook(path, data_only=True)
+    ws = wb[GRADE_SHEET]
+
+    index = GradeIndex()
+    for r in range(2, ws.max_row + 1):  # строка 1 — заголовок
+        name = ws.cell(r, GRADE_NAME_COL).value
+        if not name:
+            continue
+        dob_raw = ws.cell(r, GRADE_DOB_COL).value
+        mean = ws.cell(r, GRADE_MEAN_COL).value
+        if mean in (None, ""):
+            continue
+        try:
+            mean = float(mean)
+        except (TypeError, ValueError):
+            continue
+        index.add(name, dob_raw, mean)
+
+    return index
+
+
+# ===========================================================================
+# Расчёт value_to_store и score для одного упражнения одного человека
+# ===========================================================================
+def _score_exercise(etype, kind, rcol, ocol, conv, raw_entry, age, ws=None, row=None,
+                    committee_o=None):
+    """Вернуть (value_to_store, score, extra_params) для одного упражнения.
+
+    raw_entry — то, что положил load_fizo в rec["raw"][etype]:
+        число (счётные/бег) либо кортеж ('kettle', reps, weight).
+    committee_o — подписанный комиссией балл О (для committee-режима инверсии).
+
+    value_to_store — то, что реально запишется в DAL / протокол (для беговых в
+    committee-режиме это примагниченный к сетке порог; выносливость всегда в
+    десятичных минутах). score — балл под DAL от value_to_store.
+    """
+    extra_params: dict = {}
+
+    # --- определяем СЫРОЕ value_to_store для каждого вида упражнения ---
+    if kind == "kettle":
+        _tag, reps, weight = raw_entry
+        raw_value = int(reps)
+        extra_params = {"weight": weight}
+    elif kind == "int":
+        raw_value = int(raw_entry)
+    elif kind == "mmss":
+        raw_value = mmss_to_decmin(float(raw_entry))  # десятичные минуты
+    else:  # 'sec'
+        raw_value = float(raw_entry)
+
+    # --- verbatim: храним сырое, балл = дословный О комиссии ---
+    if SCORING_MODE == "verbatim":
+        score = int(committee_o) if committee_o is not None else conv(
+            raw_value, extra_params, age
+        )
+        return raw_value, score, extra_params
+
+    # --- committee/strict: балл пересчитывается по scoring.py из value ---
+    if kind in ("kettle", "int"):
+        score = conv(raw_value, extra_params, age)
+        return raw_value, score, extra_params
+
+    # Беговые упражнения (kind in {'sec','mmss'}) для committee/strict.
+    raw_dv = raw_value
+
+    if SCORING_MODE == "committee":
+        table = TIME_TABLES[etype]
+        # Инверсия: порог сетки, дающий подписанный О комиссии под DAL.
+        if committee_o and committee_o > 0:
+            snapped = invert_time(table, committee_o)
+        else:
+            snapped = None
+        if snapped is not None:
+            value_to_store = snapped
+            score = conv(value_to_store, {}, age)
+        else:
+            # Фолбэк: О==0 либо не выражается порогом — храним сырое,
+            # score = его собственный балл под DAL.
+            value_to_store = raw_dv
+            score = conv(value_to_store, {}, age)
+    else:  # strict
+        value_to_store = raw_dv
+        score = conv(value_to_store, {}, age)
+
+    return value_to_store, score, extra_params
+
+
+# ===========================================================================
+# Главная функция: compute_fill(name, dob) -> dict
+# ===========================================================================
+def compute_fill(name, dob, fizo: FizoIndex, grades: GradeIndex) -> dict:
+    """Собрать все итоговые значения протокола для одного человека.
+
+    Зеркалит comp_sel_protocol._make_applicant_row / _select_best_exercises:
+      * по каждому направлению берём упражнение с МАКСИМАЛЬНЫМ score;
+      * strength/speed/endurance_score = max score в направлении (0 если нет);
+      * total_score = сумма трёх;
+      * physical_test_grade = scoring.compute_global_score(...);
+      * mean_grade_scaled = int(mean_grade*10);
+      * final_result = physical_test_grade + mean_grade_scaled.
+    """
+    result = {
+        "name": str(name).strip() if name else "",
+        "dob": norm_dob(dob),
+        "matched": False,
+        "match_kind": None,
+        "age": None,
+        "directions": {STRENGTH: None, SPEED: None, ENDURANCE: None},
+        "strength_score": 0,
+        "speed_score": 0,
+        "endurance_score": 0,
+        "total_score": 0,
+        "physical_test_grade": 0,
+        "mean_grade": None,
+        "mean_grade_scaled": None,
+        "final_result": 0,
+        "exercise_results": [],
+    }
+
+    rec, kind = fizo.lookup(name, dob)
+
+    # --- средний балл (сопоставляется независимо от ФИЗО) ---
+    mg, _mg_kind = grades.lookup(name, dob)
+    if mg is not None:
+        result["mean_grade"] = mg
+        result["mean_grade_scaled"] = int(mg * 10)
+
+    if rec is None:
+        # Нет ФИЗО: физподготовка = 0, но итог включает успеваемость.
+        scaled = result["mean_grade_scaled"] or 0
+        result["final_result"] = 0 + scaled
+        return result
+
+    result["matched"] = True
+    result["match_kind"] = kind
+    age = rec["age"]
+    result["age"] = age
+
+    # Лучшее упражнение в каждом направлении (по МАКСИМАЛЬНОМУ score).
+    best: dict[str, dict] = {}
+    exercise_results: list[dict] = []
+
+    for (etype, rcol, ocol, conv, direction, number, kind_ex) in EXODEF:
+        raw_entry = rec["raw"].get(etype)
+        if raw_entry is None:
+            continue  # упражнение не выполнялось
+
+        committee_o = int(_num(rec.get("committee_o", {}).get(etype, 0)))
+
+        value_to_store, score, extra_params = _score_exercise(
+            etype, kind_ex, rcol, ocol, conv, raw_entry, age,
+            committee_o=committee_o,
+        )
+
+        exercise_results.append({
+            "exercise_type": etype,
+            "value_to_store": value_to_store,
+            "secondary_score": score,
+            "extra_params": extra_params,
+        })
+
+        existing = best.get(direction)
+        if existing is None or score > existing["score"]:
+            best[direction] = {
+                "number": EXERCISE_NUMBERS.get(etype, ""),
+                "value_to_store": value_to_store,
+                "result_display": _format_exercise_value(value_to_store, etype),
+                "score": score,
+                "exercise_type": etype,
+            }
+
+    result["exercise_results"] = exercise_results
+
+    for direction in (STRENGTH, SPEED, ENDURANCE):
+        result["directions"][direction] = best.get(direction)
+
+    st = best[STRENGTH]["score"] if STRENGTH in best else 0
+    sp = best[SPEED]["score"] if SPEED in best else 0
+    en = best[ENDURANCE]["score"] if ENDURANCE in best else 0
+
+    result["strength_score"] = st
+    result["speed_score"] = sp
+    result["endurance_score"] = en
+    result["total_score"] = st + sp + en
+
+    if SCORING_MODE == "verbatim":
+        # Итог по 100-балльной — дословно из ведомости комиссии.
+        result["physical_test_grade"] = rec["committee_agg"]["physical_test_grade"]
+    else:
+        result["physical_test_grade"] = scoring.compute_global_score(st, sp, en, age)
+
+    scaled = result["mean_grade_scaled"] or 0
+    result["final_result"] = result["physical_test_grade"] + scaled
+
+    return result
+
+
+def _format_exercise_value(value, exercise_type=None):
+    """Зеркало back-end comp_sel_protocol._format_exercise_value (+ мм:сс)."""
+    if value is None:
+        return ""
+    if exercise_type in _MMSS_EXERCISES and isinstance(value, (int, float)):
+        total_seconds = round(value * 60)
+        return f"{total_seconds // 60}:{total_seconds % 60:02d}"
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return round(value, 2) if isinstance(value, float) else value
+
+
+# ===========================================================================
+# Отчёт: какие имена из ФИЗО НЕ попадут в протокол (raw-индекс наружу)
+# ===========================================================================
+def unmatched_fizo_report(fizo: FizoIndex, protocol_keys) -> list[dict]:
+    """Вернуть список записей ФИЗО, чей (name,dob)-ключ отсутствует среди
+    protocol_keys (итерабельное из (name, dob) протоколов). Полезно понять,
+    кто из ведомости не найдёт свою строку в протоколах.
+    """
+    wanted = {_key(n, d) for (n, d) in protocol_keys}
+    missing = []
+    for rec in fizo.records:
+        if _key(rec["name"], rec["dob_raw"]) not in wanted:
+            missing.append(rec)
+    return missing
+
+
+# Обратно-совместимый алиас: раньше полный загрузчик назывался load_fizo_full.
+# Теперь load_fizo сам читает committee_o, так что это один и тот же вызов.
+load_fizo_full = load_fizo
+
+
+# ===========================================================================
+# Демонстрация / самопроверка
+# ===========================================================================
+def _print_fill(title, fill):
+    print(f"\n--- {title} ---")
+    print(f"  matched={fill['matched']} match_kind={fill['match_kind']} age={fill['age']}")
+    dir_names = {STRENGTH: "СИЛА     ", SPEED: "БЫСТРОТА ", ENDURANCE: "ВЫНОСЛИВ."}
+    for d in (STRENGTH, SPEED, ENDURANCE):
+        info = fill["directions"][d]
+        if info is None:
+            print(f"  {dir_names[d]}: —")
+        else:
+            print(
+                f"  {dir_names[d]}: №{info['number']} {info['exercise_type']:18s}"
+                f" store={info['value_to_store']!r:>8} disp={info['result_display']!r:>8}"
+                f" score={info['score']}"
+            )
+    print(
+        f"  strength={fill['strength_score']} speed={fill['speed_score']}"
+        f" endurance={fill['endurance_score']} total={fill['total_score']}"
+    )
+    print(
+        f"  physical_test_grade={fill['physical_test_grade']}"
+        f"  mean_grade={fill['mean_grade']} mean_grade_scaled={fill['mean_grade_scaled']}"
+        f"  final_result={fill['final_result']}"
+    )
+    print(f"  exercise_results ({len(fill['exercise_results'])}):")
+    for er in fill["exercise_results"]:
+        print(f"      {er['exercise_type']:18s} value_to_store={er['value_to_store']!r}"
+              f" extra_params={er['extra_params']}")
+
+
+def main():
+    # Самопроверка импорта настоящего scoring.py
+    assert hasattr(scoring, "convert_pull_ups"), "scoring.py import failed"
+    assert scoring.convert_pull_ups(25, {}, 19) == 100, "scoring sanity check failed"
+    assert scoring.convert_run_60m(7.8, {}, 19) == 100, "scoring sanity check failed"
+    print("scoring import OK (convert_pull_ups(25)=100, convert_run_60m(7.8)=100)")
+
+    print(f"SCORING_MODE = {SCORING_MODE!r}")
+
+    fizo = load_fizo()
+    grades = load_grades()
+
+    print(f"ФИЗО people loaded    : {len(fizo.records)}")
+    print(f"grade people loaded   : {len(grades.records)}")
+
+    # Три демо-персоны: 2 из ФИЗО «до 25» + один ВАВТ.
+    demos = [
+        ("Абрамов Андрей Игоревич", "07.03.2007"),
+        ("Авдеев Алексей Дмитриевич", "03.01.2007"),
+        ("Архиреев Лев Андреевич", "16.11.2006"),  # ВАВТ (протокол 225 (543))
+    ]
+    for name, dob in demos:
+        fill = compute_fill(name, dob, fizo, grades)
+        _print_fill(f"{name} / {dob}", fill)
+
+    print("\nОК: core.py загрузился, посчитал и прошёл самопроверки.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/dal-fill/fill_manual.py
+++ b/tools/dal-fill/fill_manual.py
@@ -1,0 +1,252 @@
+"""
+fill_manual.py — Вариант 1 (ручной): заполняет копии существующих xlsx-протоколов
+"Протокол конкурсного отбора" физическими результатами (ФИЗО) и средним баллом.
+
+Логика чисел — ТОЛЬКО из общего модуля core.py (compute_fill). Второй путь
+(prod-API) использует тот же core.py, поэтому итоговые значения обязаны совпасть.
+
+Что делает:
+  * Копирует каждый протокол из ~/Downloads/dal-fill-db/Протоколы/*.xlsx в
+    ~/Downloads/dal-fill-db/artifacts/manual/ (загружает настоящую книгу openpyxl,
+    правит на месте, сохраняет по новому пути — формат сохраняется, НЕ регенерирует).
+  * По каждому листу идёт по строкам данных (данные с row 20; строка данных — это
+    col B = ФИО \n DD.MM.YYYY). Разбирает имя+дату, зовёт core.compute_fill.
+  * Пишет колонки по порядку из comp_sel_protocol (1-based A..W):
+        G,H,I = STRENGTH  номер,результат,балл
+        J,K,L = SPEED
+        M,N,O = ENDURANCE
+        P     = общий балл (total_score)
+        R     = оценка физподготовки (physical_test_grade)
+        U     = успеваемость (mean_grade_scaled)
+        V     = итоговый результат (final_result)
+    Пустое направление -> 3 ячейки пустые. Нет среднего балла -> U не трогаем,
+    V = physical_test_grade (зеркало: final = physical_test_grade + (scaled or 0)).
+    НЕ трогаем A,B,C,D,E,F,Q,S,T,W.
+  * Физику пишем только тем, кто найден в ФИЗО; средний балл — только найденным
+    в "Средний балл".
+  * Пишет artifacts/manual/report.json и report.txt.
+
+Запуск:  python3 tools/dal-fill/fill_manual.py
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import openpyxl
+
+import core
+
+# ---------------------------------------------------------------------------
+# Пути
+# ---------------------------------------------------------------------------
+DATA = core.DATA
+PROTO_SRC_DIR = DATA / "Протоколы"
+OUT_DIR = DATA / "artifacts" / "manual"
+
+DATA_START_ROW = 20  # первая строка данных в каждом листе протокола
+
+# ---------------------------------------------------------------------------
+# Колонки протокола (1-based), зеркало comp_sel_protocol._make_applicant_row.
+#   Порядок ячеек строки: A(1) № | B(2) ФИО+ДР | C(3) код | D(4) годность |
+#   E(5) проф-псих | F(6) возр.группа |
+#   G(7)/H(8)/I(9)   СИЛА  номер/результат/балл
+#   J(10)/K(11)/L(12) БЫСТРОТА
+#   M(13)/N(14)/O(15) ВЫНОСЛИВОСТЬ
+#   P(16) общий балл | Q(17) соответствие | R(18) оценка физо |
+#   S(19) 10% | T(20) преимущ. | U(21) успеваемость | V(22) итог | W(23) решение
+# ---------------------------------------------------------------------------
+COL = {
+    "ST_NUM": 7,  "ST_RES": 8,  "ST_SCORE": 9,
+    "SP_NUM": 10, "SP_RES": 11, "SP_SCORE": 12,
+    "EN_NUM": 13, "EN_RES": 14, "EN_SCORE": 15,
+    "TOTAL": 16,          # P
+    "PHYS_GRADE": 18,     # R
+    "MEAN_SCALED": 21,    # U
+    "FINAL": 22,          # V
+}
+
+DIRECTIONS = [
+    (core.STRENGTH, "ST_NUM", "ST_RES", "ST_SCORE"),
+    (core.SPEED,    "SP_NUM", "SP_RES", "SP_SCORE"),
+    (core.ENDURANCE, "EN_NUM", "EN_RES", "EN_SCORE"),
+]
+
+
+def parse_cell_b(value):
+    """Из 'ФИО\\nDD.MM.YYYY' вернуть (name, dob) либо (None, None), если это не
+    строка данных (нет перевода строки => заголовок/пусто)."""
+    if value is None:
+        return None, None
+    s = str(value)
+    if "\n" not in s:
+        return None, None
+    parts = s.split("\n")
+    name = parts[0].strip()
+    dob = parts[1].strip() if len(parts) > 1 else ""
+    if not name:
+        return None, None
+    return name, dob
+
+
+def fill_sheet(ws, fizo, grades, stats):
+    """Заполнить один лист. stats — dict-аккумулятор для отчёта."""
+    for r in range(DATA_START_ROW, ws.max_row + 1):
+        a = ws.cell(r, 1).value
+        # Граница: начало раздела 2 (не прошедшие отбор).
+        if isinstance(a, str) and a.strip().startswith("2. Список"):
+            break
+
+        name, dob = parse_cell_b(ws.cell(r, 2).value)
+        if name is None:
+            continue  # спейсер / пустая строка
+
+        stats["total_rows"] += 1
+        fill = core.compute_fill(name, dob, fizo, grades)
+
+        # --- Физподготовка: только если найден в ФИЗО ---
+        if fill["matched"]:
+            stats["physical_filled"] += 1
+            for direction, num_k, res_k, score_k in DIRECTIONS:
+                info = fill["directions"][direction]
+                if info is None:
+                    # Направление отсутствует -> оставляем 3 ячейки пустыми.
+                    continue
+                ws.cell(r, COL[num_k]).value = info["number"]
+                ws.cell(r, COL[res_k]).value = info["result_display"]
+                ws.cell(r, COL[score_k]).value = info["score"]
+            ws.cell(r, COL["TOTAL"]).value = fill["total_score"]
+            ws.cell(r, COL["PHYS_GRADE"]).value = fill["physical_test_grade"]
+        else:
+            stats["unmatched_physical"].append(f"{name} | {dob}")
+
+        # --- Средний балл: только если найден в "Средний балл" ---
+        if fill["mean_grade_scaled"] is not None:
+            stats["grade_filled"] += 1
+            ws.cell(r, COL["MEAN_SCALED"]).value = fill["mean_grade_scaled"]
+        else:
+            stats["unmatched_grade"] += 1
+            stats["unmatched_grade_names"].append(f"{name} | {dob}")
+
+        # --- Итоговый результат V (всегда, зеркало core.final_result) ---
+        # final_result = physical_test_grade + (mean_grade_scaled or 0).
+        # Если физики нет -> physical_test_grade==0 => V == (scaled or 0).
+        ws.cell(r, COL["FINAL"]).value = fill["final_result"]
+
+
+def main():
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    fizo = core.load_fizo()
+    grades = core.load_grades()
+
+    src_files = sorted(p for p in PROTO_SRC_DIR.glob("*.xlsx")
+                       if not p.name.startswith("~$"))
+
+    report = {
+        "scoring_mode": core.SCORING_MODE,
+        "fizo_people": len(fizo.records),
+        "grade_people": len(grades.records),
+        "protocols": [],
+        "totals": {
+            "total_rows": 0,
+            "physical_filled": 0,
+            "grade_filled": 0,
+            "unmatched_physical": 0,
+            "unmatched_grade": 0,
+        },
+    }
+
+    for src in src_files:
+        dst = OUT_DIR / src.name
+        shutil.copy2(src, dst)  # сначала байтовая копия (сохраняет всё)
+
+        wb = openpyxl.load_workbook(dst)  # правим настоящую книгу, не регенерируем
+
+        proto_stats = {
+            "file": src.name,
+            "sheets": [],
+            "total_rows": 0,
+            "physical_filled": 0,
+            "grade_filled": 0,
+            "unmatched_physical": [],
+            "unmatched_grade": 0,
+            "unmatched_grade_names": [],
+        }
+
+        for sn in wb.sheetnames:
+            ws = wb[sn]
+            before = dict(
+                total=proto_stats["total_rows"],
+                phys=proto_stats["physical_filled"],
+                grade=proto_stats["grade_filled"],
+            )
+            fill_sheet(ws, fizo, grades, proto_stats)
+            proto_stats["sheets"].append({
+                "sheet": sn,
+                "rows": proto_stats["total_rows"] - before["total"],
+                "physical_filled": proto_stats["physical_filled"] - before["phys"],
+                "grade_filled": proto_stats["grade_filled"] - before["grade"],
+            })
+
+        wb.save(dst)
+
+        report["protocols"].append(proto_stats)
+        report["totals"]["total_rows"] += proto_stats["total_rows"]
+        report["totals"]["physical_filled"] += proto_stats["physical_filled"]
+        report["totals"]["grade_filled"] += proto_stats["grade_filled"]
+        report["totals"]["unmatched_physical"] += len(proto_stats["unmatched_physical"])
+        report["totals"]["unmatched_grade"] += proto_stats["unmatched_grade"]
+
+    # ---- report.json ----
+    (OUT_DIR / "report.json").write_text(
+        json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    # ---- report.txt (человекочитаемый) ----
+    lines = []
+    lines.append("ОТЧЁТ ЗАПОЛНЕНИЯ ПРОТОКОЛОВ (Вариант 1 — ручной xlsx)")
+    lines.append(f"SCORING_MODE = {report['scoring_mode']}")
+    lines.append(f"ФИЗО загружено людей : {report['fizo_people']}")
+    lines.append(f"Средний балл загружено: {report['grade_people']}")
+    lines.append(f"Выходная папка: {OUT_DIR}")
+    lines.append("")
+    lines.append("ИТОГО ПО ВСЕМ ПРОТОКОЛАМ:")
+    t = report["totals"]
+    lines.append(f"  строк данных всего     : {t['total_rows']}")
+    lines.append(f"  физика заполнена       : {t['physical_filled']}")
+    lines.append(f"  средний балл заполнен  : {t['grade_filled']}")
+    lines.append(f"  без физики (не найдены): {t['unmatched_physical']}")
+    lines.append(f"  без среднего балла     : {t['unmatched_grade']}")
+    lines.append("")
+    lines.append("=" * 70)
+
+    for p in report["protocols"]:
+        lines.append("")
+        lines.append(f"ПРОТОКОЛ: {p['file']}")
+        lines.append(f"  строк данных всего     : {p['total_rows']}")
+        lines.append(f"  физика заполнена       : {p['physical_filled']}")
+        lines.append(f"  средний балл заполнен  : {p['grade_filled']}")
+        lines.append(f"  без физики (кол-во)    : {len(p['unmatched_physical'])}")
+        lines.append(f"  без среднего балла     : {p['unmatched_grade']}")
+        for s in p["sheets"]:
+            lines.append(
+                f"    лист {s['sheet']!r}: строк={s['rows']} "
+                f"физика={s['physical_filled']} ср.балл={s['grade_filled']}"
+            )
+        if p["unmatched_physical"]:
+            lines.append("  НЕ НАЙДЕНЫ В ФИЗО:")
+            for nm in p["unmatched_physical"]:
+                lines.append(f"    - {nm}")
+
+    (OUT_DIR / "report.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    print("\n".join(lines))
+    print(f"\nreport.json -> {OUT_DIR / 'report.json'}")
+    print(f"report.txt  -> {OUT_DIR / 'report.txt'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/dal-fill/fill_prod.py
+++ b/tools/dal-fill/fill_prod.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+"""
+fill_prod.py — Вариант 2 (prod) заполнения "Протокола конкурсного отбора".
+
+Заливает физподготовку (ФИЗО) ДОСЛОВНО через ручку ручного ввода и средний балл
+в DAL API по HTTP, после чего DAL заново экспортирует протокол. Итоговые числа
+берутся из ЕДИНОГО общего модуля tools/dal-fill/core.py (тот же, что использует
+ручной Вариант 1), поэтому оба пути обязаны дать идентичный протокол.
+
+Что делает:
+  1. Аутентификация: POST email+password на /api/auth/tokens/obtain/
+     (можно передать готовый --token).
+  2. Список абитуриентов с заявками (пагинация) через
+     GET /api/ams/applicants/applications/?campus=... — строит карту
+     normalized(name, dob) -> {id, mean_grade, aggregates, existing exercise_results}.
+  3. Физподготовка (ДОСЛОВНО, без пересчёта) через ручку override:
+       POST /api/ams/applicants/{id}/exercise-results/override/
+       {results:[{exercise_type, value, secondary_score, extra_params}...],
+        strength_score, speed_score, endurance_score, physical_test_grade}
+     Балл secondary_score и агрегаты пишутся как есть (это числа комиссии).
+  4. Средний балл — политика fill-empty-plus-report-conflicts:
+       PATCH /api/ams/applicants/{id}/application/ {mean_grade: committee_value}
+       ТОЛЬКО если mean_grade в БД == 0/пусто. Иначе, если отличается — конфликт
+       (пишем в отчёт), НЕ перезаписываем.
+
+Замечание по маппингу: core отдаёт exercise_results как
+{exercise_type, value_to_store, secondary_score, extra_params}; ручка override
+ждёт {exercise_type, value, secondary_score, extra_params}. value_to_store -> value.
+
+БЕЗОПАСНОСТЬ:
+  * По умолчанию DRY-RUN: без --execute сервер НЕ мутируется. Реальный прогон по
+    проду — РУЧНОЙ шаг пользователя. Скрипт лишь готовит и печатает план.
+  * В dry-run печатается полный PLAN (JSON) и пишется в
+    ~/Downloads/dal-fill-db/artifacts/prod/plan.json.
+  * Идемпотентно/resumable: override заменяет весь набор результатов; grade —
+    fill-empty по факту текущего состояния (перечитывается каждый прогон).
+
+Примеры запуска:
+  # Собрать план из xlsx БЕЗ HTTP (мок карты абитуриентов из имён ФИЗО):
+  python3 tools/dal-fill/fill_prod.py --self-check
+
+  # Dry-run против сервера (читает, но НЕ пишет); печатает и сохраняет план:
+  python3 tools/dal-fill/fill_prod.py --base-url http://localhost:1112 \
+      --email admin@mail.ru --password secret
+
+  # Реально записать (РУЧНОЙ шаг пользователя):
+  python3 tools/dal-fill/fill_prod.py --base-url https://dal.example \
+      --token "$JWT" --execute
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import requests
+
+# Импорт общего модуля (лежит рядом).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import core  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Константы путей / API
+# ---------------------------------------------------------------------------
+ARTIFACTS_DIR = core.DATA / "artifacts" / "prod"
+PLAN_PATH = ARTIFACTS_DIR / "plan.json"
+
+DEFAULT_BASE_URL = "http://localhost:1112"
+
+TOKEN_OBTAIN_PATH = "/api/auth/tokens/obtain/"
+APPLICATIONS_PATH = "/api/ams/applicants/applications/"
+
+
+def _override_path(applicant_id) -> str:
+    return f"/api/ams/applicants/{applicant_id}/exercise-results/override/"
+
+
+def _application_path(applicant_id) -> str:
+    return f"/api/ams/applicants/{applicant_id}/application/"
+
+
+# Кампусы физподготовки: только Москва + ВАВТ (в ведомости нет СПб/НН/Перми).
+PHYSICAL_CAMPUSES = ["MO", "VA"]
+
+
+# ===========================================================================
+# HTTP-клиент
+# ===========================================================================
+class DalClient:
+    """Тонкий requests-клиент к DAL API.
+
+    Никогда не выполняет мутирующих запросов, если execute=False:
+    POST/PATCH возвращают синтетический ответ-заглушку (dry-run).
+    """
+
+    def __init__(self, base_url: str, token: str | None = None,
+                 execute: bool = False, timeout: float = 30.0):
+        self.base_url = base_url.rstrip("/")
+        self.execute = execute
+        self.timeout = timeout
+        self.session = requests.Session()
+        if token:
+            self.session.headers["Authorization"] = f"Bearer {token}"
+
+    # ---- auth -----------------------------------------------------------
+    def obtain_token(self, email: str, password: str) -> str:
+        """POST email+password -> access-токен; ставит Authorization header."""
+        url = self.base_url + TOKEN_OBTAIN_PATH
+        resp = self.session.post(
+            url, json={"email": email, "password": password}, timeout=self.timeout
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        token = data.get("access") or data.get("access_token")
+        if not token:
+            raise RuntimeError(f"No access token in response: {data!r}")
+        self.session.headers["Authorization"] = f"Bearer {token}"
+        return token
+
+    # ---- read -----------------------------------------------------------
+    def list_applications(self, campus: str, page_size: int = 200):
+        """Итерирует всех абитуриентов кампуса (следует пагинации DRF)."""
+        url = self.base_url + APPLICATIONS_PATH
+        params = {"campus": campus, "page_size": page_size}
+        while url:
+            resp = self.session.get(url, params=params, timeout=self.timeout)
+            resp.raise_for_status()
+            data = resp.json()
+            if isinstance(data, dict) and "results" in data:
+                yield from data["results"]
+                url = data.get("next")
+                params = None  # next уже содержит query
+            else:  # непагинированный ответ
+                yield from data
+                url = None
+
+    # ---- write (гейтятся через execute) --------------------------------
+    def override_physical(self, applicant_id, body: dict) -> dict:
+        """POST на ручку override — дословная заливка физ. результатов."""
+        url = self.base_url + _override_path(applicant_id)
+        if not self.execute:
+            return {"_dry_run": True, "method": "POST", "url": url, "body": body}
+        resp = self.session.post(url, json=body, timeout=self.timeout)
+        resp.raise_for_status()
+        return {"status_code": resp.status_code}
+
+    def patch_application(self, applicant_id, body: dict) -> dict:
+        url = self.base_url + _application_path(applicant_id)
+        if not self.execute:
+            return {"_dry_run": True, "method": "PATCH", "url": url, "body": body}
+        resp = self.session.patch(url, json=body, timeout=self.timeout)
+        resp.raise_for_status()
+        return resp.json()
+
+
+# ===========================================================================
+# Построение карты абитуриентов из ответа API (или мока)
+# ===========================================================================
+def _applicant_record_from_api(item: dict) -> dict:
+    """Нормализовать один элемент /applicants/applications/ в запись карты."""
+    ap = item.get("application_process") or {}
+    existing = {}
+    for er in (ap.get("exercise_results") or []):
+        et = er.get("exercise_type")
+        if et is not None:
+            existing[et] = er
+
+    mean_raw = ap.get("mean_grade", 0)
+    try:
+        mean_grade = float(mean_raw) if mean_raw not in (None, "") else 0.0
+    except (TypeError, ValueError):
+        mean_grade = 0.0
+
+    return {
+        "id": item.get("id"),
+        "fullname": item.get("fullname", "") or "",
+        "birth_date": item.get("birth_date"),
+        "mean_grade": mean_grade,
+        "aggregates": {
+            "strength_score": ap.get("strength_score"),
+            "speed_score": ap.get("speed_score"),
+            "endurance_score": ap.get("endurance_score"),
+            "physical_test_grade": ap.get("physical_test_grade"),
+        },
+        "existing_exercises": existing,
+    }
+
+
+def build_applicant_map(client: DalClient, campuses: list[str],
+                        limit: int | None = None) -> dict:
+    """Собрать normalized(name, dob) -> applicant record из API."""
+    amap: dict[tuple[str, str], dict] = {}
+    count = 0
+    for campus in campuses:
+        for item in client.list_applications(campus):
+            rec = _applicant_record_from_api(item)
+            key = core._key(rec["fullname"], rec["birth_date"])
+            amap.setdefault(key, rec)
+            count += 1
+            if limit is not None and count >= limit:
+                return amap
+    return amap
+
+
+def build_mock_applicant_map_from_fizo(fizo: core.FizoIndex,
+                                       limit: int | None = None) -> dict:
+    """Мок карты абитуриентов для --self-check (без HTTP)."""
+    amap: dict[tuple[str, str], dict] = {}
+    for i, rec in enumerate(fizo.records, start=1):
+        key = core._key(rec["name"], rec["dob_raw"])
+        if key in amap:
+            continue
+        amap[key] = {
+            "id": 900000 + i,          # синтетический id
+            "fullname": rec["name"],
+            "birth_date": rec["dob"],  # dd.mm.yyyy — core нормализует одинаково
+            "mean_grade": 0.0,
+            "aggregates": {},
+            "existing_exercises": {},
+        }
+        if limit is not None and len(amap) >= limit:
+            break
+    return amap
+
+
+# ===========================================================================
+# Построение плана (без HTTP)
+# ===========================================================================
+def _override_body_from_fill(fill: dict) -> dict:
+    """Собрать тело запроса к ручке override из результата core.compute_fill."""
+    results = [
+        {
+            "exercise_type": er["exercise_type"],
+            "value": er["value_to_store"],
+            "secondary_score": er["secondary_score"],
+            "extra_params": er["extra_params"],
+        }
+        for er in fill["exercise_results"]
+    ]
+    return {
+        "results": results,
+        "strength_score": fill["strength_score"],
+        "speed_score": fill["speed_score"],
+        "endurance_score": fill["endurance_score"],
+        "physical_test_grade": fill["physical_test_grade"],
+    }
+
+
+def build_plan(applicant_map: dict, fizo: core.FizoIndex, grades: core.GradeIndex,
+               *, do_physical: bool, do_grade: bool) -> dict:
+    """Собрать план намеченных действий для каждого совпавшего абитуриента."""
+    plan = {
+        "meta": {
+            "scoring_mode": core.SCORING_MODE,
+            "age_ref_date": core.AGE_REF_DATE.isoformat(),
+            "do_physical": do_physical,
+            "do_grade": do_grade,
+            "applicants_in_map": len(applicant_map),
+        },
+        "physical_overrides": [],
+        "grade_patches": [],
+        "grade_conflicts": [],
+        "unmatched_fizo": [],   # есть в ФИЗО, но нет абитуриента в карте
+        "matched_no_data": [],  # абитуриент есть, но нет ни ФИЗО, ни грейда
+    }
+
+    matched_keys = set()
+
+    for key, applicant in applicant_map.items():
+        name = applicant["fullname"]
+        dob = applicant["birth_date"]
+        aid = applicant["id"]
+
+        fill = core.compute_fill(name, dob, fizo, grades)
+        touched = False
+
+        # ---- физподготовка (ДОСЛОВНО через override) -------------------
+        # Пропускаем тех, кто в ведомости есть, но не выполнил ни одного
+        # упражнения (все нули) — заливать нечего, пустой override не нужен.
+        if do_physical and fill["matched"] and fill["exercise_results"]:
+            touched = True
+            plan["physical_overrides"].append({
+                "applicant_id": aid,
+                "name": name,
+                "dob": fill["dob"],
+                "old": {
+                    "aggregates": applicant.get("aggregates", {}),
+                    "existing_exercise_types": sorted(
+                        applicant.get("existing_exercises", {}).keys()
+                    ),
+                },
+                "body": _override_body_from_fill(fill),
+            })
+
+        # ---- средний балл (fill-empty-plus-report-conflicts) -----------
+        if do_grade and fill["mean_grade"] is not None:
+            touched = True
+            committee = float(fill["mean_grade"])
+            db_grade = float(applicant.get("mean_grade") or 0.0)
+            entry = {
+                "applicant_id": aid,
+                "name": name,
+                "dob": fill["dob"],
+                "db_mean_grade": db_grade,
+                "committee_mean_grade": committee,
+            }
+            if db_grade <= 0:
+                plan["grade_patches"].append({
+                    **entry,
+                    "old": db_grade,
+                    "new": committee,
+                    "body": {"mean_grade": committee},
+                })
+            elif abs(db_grade - committee) > 1e-9:
+                plan["grade_conflicts"].append(entry)
+            # else: совпало — ничего не делаем.
+
+        if touched:
+            matched_keys.add(key)
+        elif fill["matched"] is False and fill["mean_grade"] is None:
+            plan["matched_no_data"].append({
+                "applicant_id": aid, "name": name, "dob": fill["dob"],
+            })
+
+    # ---- кто из ФИЗО не нашёл абитуриента в карте --------------------
+    map_keys = list(applicant_map.keys())
+    for rec in core.unmatched_fizo_report(fizo, [(k[0], k[1]) for k in map_keys]):
+        plan["unmatched_fizo"].append({
+            "name": rec["name"], "dob": rec["dob"], "row": rec["row"],
+        })
+
+    plan["counts"] = {
+        "physical_overrides": len(plan["physical_overrides"]),
+        "grade_patches": len(plan["grade_patches"]),
+        "grade_conflicts": len(plan["grade_conflicts"]),
+        "unmatched_fizo": len(plan["unmatched_fizo"]),
+        "matched_no_data": len(plan["matched_no_data"]),
+        "applicants_touched": len(matched_keys),
+    }
+    return plan
+
+
+def write_plan(plan: dict) -> Path:
+    ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+    PLAN_PATH.write_text(
+        json.dumps(plan, ensure_ascii=False, indent=2, default=str),
+        encoding="utf-8",
+    )
+    return PLAN_PATH
+
+
+# ===========================================================================
+# Исполнение плана против сервера (идемпотентно / resumable)
+# ===========================================================================
+def execute_plan(client: DalClient, plan: dict) -> dict:
+    """Применить план. При execute=False клиент вернёт заглушки (dry-run)."""
+    results = {"physical": [], "grade": []}
+
+    for item in plan["physical_overrides"]:
+        r = client.override_physical(item["applicant_id"], item["body"])
+        results["physical"].append({
+            "applicant_id": item["applicant_id"], "name": item["name"], "resp": r,
+        })
+
+    for item in plan["grade_patches"]:
+        r = client.patch_application(item["applicant_id"], item["body"])
+        results["grade"].append({
+            "applicant_id": item["applicant_id"], "name": item["name"], "resp": r,
+        })
+
+    return results
+
+
+# ===========================================================================
+# CLI
+# ===========================================================================
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="fill_prod.py",
+        description=(
+            "Вариант 2 (prod): дословная заливка ФИЗО (ручка override) и среднего "
+            "балла в DAL API. По умолчанию DRY-RUN — без --execute сервер НЕ "
+            "мутируется. Значения берутся из общего core.py."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--base-url", default=DEFAULT_BASE_URL,
+                   help=f"Базовый URL DAL (по умолчанию {DEFAULT_BASE_URL}).")
+    p.add_argument("--email", help="Email для получения JWT (или используйте --token).")
+    p.add_argument("--password", help="Пароль для получения JWT.")
+    p.add_argument("--token", help="Готовый Bearer JWT (в обход email/password).")
+
+    grp = p.add_mutually_exclusive_group()
+    grp.add_argument("--dry-run", dest="dry_run", action="store_true", default=True,
+                     help="Ничего не мутировать (по умолчанию включено).")
+    grp.add_argument("--execute", dest="dry_run", action="store_false",
+                     help="РЕАЛЬНО писать в сервер (ручной шаг пользователя).")
+
+    p.add_argument("--limit", type=int, default=None,
+                   help="Ограничить число обрабатываемых абитуриентов.")
+
+    only = p.add_mutually_exclusive_group()
+    only.add_argument("--only-physical", action="store_true",
+                      help="Только физподготовка (без среднего балла).")
+    only.add_argument("--only-grade", action="store_true",
+                      help="Только средний балл (без физподготовки).")
+
+    p.add_argument("--campus", action="append", default=None,
+                   help=("Код(ы) кампуса для листинга (можно повторять). "
+                         f"По умолчанию {PHYSICAL_CAMPUSES}."))
+
+    p.add_argument("--self-check", action="store_true",
+                   help=("Собрать план из xlsx БЕЗ HTTP: карта абитуриентов "
+                         "мокается из имён ФИЗО. Печатает counts и пишет plan.json."))
+    return p
+
+
+def _print_counts(plan: dict, header: str) -> None:
+    print(header)
+    c = plan["counts"]
+    print(f"  applicants_in_map  : {plan['meta']['applicants_in_map']}")
+    print(f"  applicants_touched : {c['applicants_touched']}")
+    print(f"  physical_overrides : {c['physical_overrides']}")
+    print(f"  grade_patches      : {c['grade_patches']}")
+    print(f"  grade_conflicts    : {c['grade_conflicts']}")
+    print(f"  unmatched_fizo     : {c['unmatched_fizo']}")
+    print(f"  matched_no_data    : {c['matched_no_data']}")
+
+
+def main(argv=None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+
+    do_physical = not args.only_grade
+    do_grade = not args.only_physical
+    campuses = args.campus or PHYSICAL_CAMPUSES
+
+    fizo = core.load_fizo()
+    grades = core.load_grades()
+
+    # ------------------------------------------------------------------
+    # SELF-CHECK: без HTTP, карта мокается из ФИЗО.
+    # ------------------------------------------------------------------
+    if args.self_check:
+        print("=== SELF-CHECK (no HTTP) ===")
+        print(f"core.SCORING_MODE = {core.SCORING_MODE!r}")
+        print(f"ФИЗО records loaded : {len(fizo.records)}")
+        print(f"grade records loaded: {len(grades.records)}")
+
+        amap = build_mock_applicant_map_from_fizo(fizo, limit=args.limit)
+        print(f"mock applicant map  : {len(amap)} (unique name+dob from ФИЗО)")
+
+        plan = build_plan(
+            amap, fizo, grades, do_physical=do_physical, do_grade=do_grade
+        )
+        path = write_plan(plan)
+        _print_counts(plan, "PLAN counts:")
+        print(f"plan.json written to: {path}")
+
+        sample = {
+            "physical_overrides_sample": plan["physical_overrides"][:2],
+            "grade_patches_sample": plan["grade_patches"][:2],
+        }
+        print("sample:")
+        print(json.dumps(sample, ensure_ascii=False, indent=2, default=str))
+        print("SELF-CHECK OK: план собран без обращения к серверу.")
+        return 0
+
+    # ------------------------------------------------------------------
+    # Реальный режим (dry-run по умолчанию): требуется соединение.
+    # ------------------------------------------------------------------
+    execute = not args.dry_run
+    client = DalClient(args.base_url, token=args.token, execute=execute)
+
+    if not args.token:
+        if not (args.email and args.password):
+            print("ERROR: нужен --token ИЛИ --email + --password (или --self-check).",
+                  file=sys.stderr)
+            return 2
+        client.obtain_token(args.email, args.password)
+
+    print(f"=== {'EXECUTE (MUTATING)' if execute else 'DRY-RUN (read-only)'} ===")
+    print(f"base_url = {args.base_url}  campuses = {campuses}")
+
+    applicant_map = build_applicant_map(client, campuses, limit=args.limit)
+    print(f"applicants fetched: {len(applicant_map)}")
+
+    plan = build_plan(
+        applicant_map, fizo, grades, do_physical=do_physical, do_grade=do_grade
+    )
+    path = write_plan(plan)
+    _print_counts(plan, "PLAN counts:")
+    print(f"plan.json written to: {path}")
+
+    if not execute:
+        print("\nDRY-RUN: сервер НЕ изменён. Полный план — в plan.json.")
+        print("Чтобы применить, перезапустите с --execute (ручной шаг пользователя).")
+        return 0
+
+    print("\nEXECUTE: применяю план...")
+    results = execute_plan(client, plan)
+    print(f"physical ops: {len(results['physical'])}  grade ops: {len(results['grade'])}")
+    print("DONE.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/dal-fill/reconcile.py
+++ b/tools/dal-fill/reconcile.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""
+reconcile.py — сверка НАМЕРЕННЫХ (intended) значений протокола для ДВУХ путей
+заполнения против единого источника истины core.compute_fill.
+
+Идея: и Вариант 1 (ручной xlsx, fill_manual.py), и Вариант 2 (prod-план,
+fill_prod.py) обязаны нести ОДНИ И ТЕ ЖЕ числа, потому что оба берут их из
+core.compute_fill. Этот скрипт независимо пересчитывает core.compute_fill для
+КАЖДОГО человека, присутствующего в ведомости ФИЗО (Москва+ВАВТ), и для каждого
+человека со средним баллом, и проверяет:
+
+  (a) Значения, которые fill_manual РЕАЛЬНО записал в artifacts/manual/*.xlsx
+      (переоткрываем xlsx, читаем колонки P(16)/R(18)/U(21)/V(22), сопоставляем
+      по имени+дате), РАВНЫ выходу core.compute_fill.
+      Расхождений быть не должно (0).
+
+  (b) План artifacts/prod/plan.json кодирует ТЕ ЖЕ значения упражнений
+      (value = value_to_store) и тот же средний балл, что даёт core.compute_fill
+      (значит DAL, пересчитав из этих значений, придёт к тому же протоколу).
+
+Точка входа сравнения — зеркало логики записи fill_manual._fill_sheet:
+  * matched (ФИЗО найден) -> P = total_score, R = physical_test_grade;
+  * grade найден         -> U = mean_grade_scaled;
+  * V = final_result всегда.
+Ячейки, которые fill_manual НЕ пишет, мы НЕ сверяем (они сохраняют исходное
+значение шаблона и к «намеренным» значениям отношения не имеют).
+
+Запуск:  python3 tools/dal-fill/reconcile.py
+Итоговый stdout = возвращаемое значение (машиночитаемый JSON-хвост + сводка).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import openpyxl
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import core  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Пути к артефактам обоих вариантов.
+# ---------------------------------------------------------------------------
+MANUAL_DIR = core.DATA / "artifacts" / "manual"
+PLAN_PATH = core.DATA / "artifacts" / "prod" / "plan.json"
+
+# Колонки протокола, которые fill_manual заполняет (1-based), зеркало
+# fill_manual.COL. Сверяем только их.
+COL_TOTAL = 16       # P  = total_score          (только если matched)
+COL_PHYS_GRADE = 18  # R  = physical_test_grade   (только если matched)
+COL_MEAN_SCALED = 21  # U = mean_grade_scaled     (только если grade найден)
+COL_FINAL = 22       # V  = final_result          (всегда)
+
+DATA_START_ROW = 20
+
+
+# ===========================================================================
+# Индекс строк протоколов из artifacts/manual/*.xlsx
+# ===========================================================================
+def build_manual_index(manual_dir: Path):
+    """Собрать (norm_name, norm_dob) -> {file, sheet, row, P, R, U, V}.
+
+    Идём по всем xlsx, всем листам, строкам данных с DATA_START_ROW до начала
+    раздела 2 (не прошедшие отбор) — ровно как fill_manual.fill_sheet.
+    Разбор ячейки B через ту же логику 'ФИО\\nDD.MM.YYYY'.
+    """
+    index: dict[tuple[str, str], dict] = {}
+    files = sorted(
+        p for p in manual_dir.glob("*.xlsx") if not p.name.startswith("~$")
+    )
+    for f in files:
+        wb = openpyxl.load_workbook(f)
+        for sn in wb.sheetnames:
+            ws = wb[sn]
+            for r in range(DATA_START_ROW, ws.max_row + 1):
+                a = ws.cell(r, 1).value
+                if isinstance(a, str) and a.strip().startswith("2. Список"):
+                    break
+                b = ws.cell(r, 2).value
+                if not b or "\n" not in str(b):
+                    continue
+                parts = str(b).split("\n")
+                name = parts[0].strip()
+                dob = parts[1].strip() if len(parts) > 1 else ""
+                if not name:
+                    continue
+                key = core._key(name, dob)
+                # На случай дубликатов ключа — берём ПЕРВЫЙ (как и остальные
+                # индексы в проекте); дубликаты фиксируем отдельно.
+                if key in index:
+                    index[key].setdefault("_dups", []).append(
+                        {"file": f.name, "sheet": sn, "row": r}
+                    )
+                    continue
+                index[key] = {
+                    "file": f.name,
+                    "sheet": sn,
+                    "row": r,
+                    "name": name,
+                    "dob": dob,
+                    "P": ws.cell(r, COL_TOTAL).value,
+                    "R": ws.cell(r, COL_PHYS_GRADE).value,
+                    "U": ws.cell(r, COL_MEAN_SCALED).value,
+                    "V": ws.cell(r, COL_FINAL).value,
+                }
+    return index, [f.name for f in files]
+
+
+def _as_num(v):
+    """Толерантно привести значение ячейки к числу для сравнения."""
+    if v is None or v == "":
+        return None
+    try:
+        f = float(v)
+        return int(f) if f.is_integer() else f
+    except (TypeError, ValueError):
+        return v
+
+
+# ===========================================================================
+# Набор людей для сверки: все ФИЗО (Москва+ВАВТ) + все со средним баллом.
+# ===========================================================================
+def build_people(fizo: core.FizoIndex, grades: core.GradeIndex):
+    """Вернуть список (name, dob_raw, sources) уникальных людей.
+
+    sources: множество из {'fizo','grade'}. Ключ уникальности — норм.(name,dob).
+    Кампусный охват физподготовки (Москва+ВАВТ) обеспечен самим источником ФИЗО
+    — в ведомости нет других кампусов. Средний балл — кто угодно.
+    """
+    people: dict[tuple[str, str], dict] = {}
+    for rec in fizo.records:
+        key = core._key(rec["name"], rec["dob_raw"])
+        p = people.setdefault(
+            key, {"name": rec["name"], "dob_raw": rec["dob_raw"], "sources": set()}
+        )
+        p["sources"].add("fizo")
+    for rec in grades.records:
+        key = core._key(rec["name"], rec["dob_raw"])
+        p = people.setdefault(
+            key, {"name": rec["name"], "dob_raw": rec["dob_raw"], "sources": set()}
+        )
+        p["sources"].add("grade")
+    return people
+
+
+# ===========================================================================
+# Ожидаемые значения ячеек манульного протокола — зеркало fill_manual.
+# ===========================================================================
+def expected_manual_cells(fill: dict) -> dict:
+    """Что fill_manual ЗАПИСАЛ БЫ для данного человека.
+
+    Возвращает dict только с теми колонками, которые fill_manual реально пишет:
+      matched -> P (total_score), R (physical_test_grade)
+      mean_grade найден -> U (mean_grade_scaled)
+      всегда -> V (final_result)
+    """
+    exp: dict[str, object] = {}
+    if fill["matched"]:
+        exp["P"] = fill["total_score"]
+        exp["R"] = fill["physical_test_grade"]
+    if fill["mean_grade_scaled"] is not None:
+        exp["U"] = fill["mean_grade_scaled"]
+    exp["V"] = fill["final_result"]
+    return exp
+
+
+# ===========================================================================
+# (a) Сверка manual xlsx
+# ===========================================================================
+def check_manual(people, fizo, grades, manual_index):
+    """Вернуть (checked, mismatches[list])."""
+    checked = 0
+    mismatches = []
+    not_in_protocol = []  # человек есть в источнике, но строки в протоколе нет
+
+    for key, person in people.items():
+        name = person["name"]
+        dob = person["dob_raw"]
+        fill = core.compute_fill(name, dob, fizo, grades)
+        row = manual_index.get(key)
+        if row is None:
+            not_in_protocol.append(
+                {"name": name, "dob": core.norm_dob(dob),
+                 "sources": sorted(person["sources"])}
+            )
+            continue
+
+        checked += 1
+        exp = expected_manual_cells(fill)
+        for col_letter, cell_key in (("P", "P"), ("R", "R"), ("U", "U"), ("V", "V")):
+            if col_letter not in exp:
+                continue  # эту колонку fill_manual не пишет — не сверяем
+            want = _as_num(exp[col_letter])
+            got = _as_num(row[cell_key])
+            if want != got:
+                mismatches.append({
+                    "name": name,
+                    "dob": core.norm_dob(dob),
+                    "file": row["file"],
+                    "sheet": row["sheet"],
+                    "row": row["row"],
+                    "column": col_letter,
+                    "expected": want,
+                    "actual": got,
+                    "matched_physical": fill["matched"],
+                    "has_grade": fill["mean_grade_scaled"] is not None,
+                })
+    return checked, mismatches, not_in_protocol
+
+
+# ===========================================================================
+# (b) Сверка prod plan.json
+# ===========================================================================
+def _plan_exercise_index(plan: dict):
+    """(norm_name, norm_dob, exercise_type) -> {value, secondary_score, extra_params}.
+
+    Читает новую структуру physical_overrides[].body.results (ручка override).
+    """
+    idx = {}
+    for item in plan.get("physical_overrides", []):
+        nn, nd = core.norm_name(item["name"]), core.norm_dob(item["dob"])
+        for er in item.get("body", {}).get("results", []):
+            idx[(nn, nd, er["exercise_type"])] = er
+    return idx
+
+
+def _plan_grade_index(plan: dict):
+    """(norm_name, norm_dob) -> committee_mean_grade (из grade_patches)."""
+    idx = {}
+    for item in plan.get("grade_patches", []):
+        k = (core.norm_name(item["name"]), core.norm_dob(item["dob"]))
+        idx[k] = item["committee_mean_grade"]
+    return idx
+
+
+def check_plan(people, fizo, grades, plan):
+    """Сверить, что план кодирует ТЕ ЖЕ per-person значения упражнений и средний
+    балл, что даёт core.compute_fill.
+
+    Проверяем ДВА направления:
+      1. Каждое упражнение из core.compute_fill.exercise_results для человека,
+         КОТОРЫЙ ЕСТЬ в карте плана, присутствует в плане с тем же value и
+         extra_params (иначе DAL пересчитает иначе).
+      2. Средний балл: для человека в grade_patches плана committee_mean_grade
+         == core mean_grade. (grade_conflicts плана НЕ трогают mean_grade, и
+         совпавшие с БД тоже — для мок-плана этого не бывает.)
+
+    Возвращает (checked, mismatches[list]).
+    """
+    ex_idx = _plan_exercise_index(plan)
+    grade_idx = _plan_grade_index(plan)
+
+    # Множество (name,dob), которых план вообще касается (touched) — по факту
+    # наличия хоть в одном ex/grade-плане. Только их значения план кодирует.
+    plan_people = set()
+    for (nn, nd, _et) in ex_idx:
+        plan_people.add((nn, nd))
+    for (nn, nd) in grade_idx:
+        plan_people.add((nn, nd))
+
+    checked = 0
+    mismatches = []
+
+    for key, person in people.items():
+        name = person["name"]
+        dob = person["dob_raw"]
+        pkey = (core.norm_name(name), core.norm_dob(dob))
+        if pkey not in plan_people:
+            # План этого человека не касается (например, graded-only, которого
+            # нет в ФИЗО-мок-карте плана). Нечего сверять — не расхождение.
+            continue
+
+        checked += 1
+        fill = core.compute_fill(name, dob, fizo, grades)
+
+        # --- 1. упражнения ---
+        for er in fill["exercise_results"]:
+            etype = er["exercise_type"]
+            want_value = _as_num(er["value_to_store"])
+            want_extra = er["extra_params"] or {}
+            planned = ex_idx.get((pkey[0], pkey[1], etype))
+            if planned is None:
+                mismatches.append({
+                    "kind": "exercise_missing_in_plan",
+                    "name": name, "dob": core.norm_dob(dob),
+                    "exercise_type": etype,
+                    "expected_value": want_value,
+                })
+                continue
+            got_value = _as_num(planned.get("value"))
+            got_extra = planned.get("extra_params") or {}
+            if want_value != got_value:
+                mismatches.append({
+                    "kind": "exercise_value",
+                    "name": name, "dob": core.norm_dob(dob),
+                    "exercise_type": etype,
+                    "expected_value": want_value, "actual_value": got_value,
+                })
+            # Дословный балл комиссии (verbatim): план обязан нести тот же
+            # secondary_score, что и core (иначе протокол разойдётся).
+            want_score = er.get("secondary_score")
+            got_score = planned.get("secondary_score")
+            if want_score is not None and want_score != got_score:
+                mismatches.append({
+                    "kind": "exercise_secondary_score",
+                    "name": name, "dob": core.norm_dob(dob),
+                    "exercise_type": etype,
+                    "expected_score": want_score, "actual_score": got_score,
+                })
+            if want_extra != got_extra:
+                mismatches.append({
+                    "kind": "exercise_extra_params",
+                    "name": name, "dob": core.norm_dob(dob),
+                    "exercise_type": etype,
+                    "expected_extra": want_extra, "actual_extra": got_extra,
+                })
+
+        # Обратная сторона: план не должен содержать «лишних» упражнений для
+        # этого человека, которых нет в core.exercise_results.
+        core_etypes = {er["exercise_type"] for er in fill["exercise_results"]}
+        for (nn, nd, et) in ex_idx:
+            if (nn, nd) == pkey and et not in core_etypes:
+                mismatches.append({
+                    "kind": "extra_exercise_in_plan",
+                    "name": name, "dob": core.norm_dob(dob),
+                    "exercise_type": et,
+                    "actual_value": _as_num(ex_idx[(nn, nd, et)].get("value")),
+                })
+
+        # --- 2. средний балл ---
+        planned_grade = grade_idx.get(pkey)
+        if planned_grade is not None:
+            want_grade = fill["mean_grade"]
+            if want_grade is None or abs(float(planned_grade) - float(want_grade)) > 1e-9:
+                mismatches.append({
+                    "kind": "mean_grade",
+                    "name": name, "dob": core.norm_dob(dob),
+                    "expected_mean_grade": want_grade,
+                    "actual_mean_grade": planned_grade,
+                })
+
+    return checked, mismatches
+
+
+# ===========================================================================
+# main
+# ===========================================================================
+def main() -> int:
+    fizo = core.load_fizo()
+    grades = core.load_grades()
+    people = build_people(fizo, grades)
+
+    manual_index, manual_files = build_manual_index(MANUAL_DIR)
+    plan = json.loads(PLAN_PATH.read_text(encoding="utf-8"))
+
+    checked_a, mism_a, not_in_proto = check_manual(
+        people, fizo, grades, manual_index
+    )
+    checked_b, mism_b = check_plan(people, fizo, grades, plan)
+
+    print("=" * 72)
+    print("RECONCILE — intended protocol values vs core.compute_fill")
+    print("=" * 72)
+    print(f"SCORING_MODE           : {core.SCORING_MODE}")
+    print(f"ФИЗО people (unique)   : {len({core._key(r['name'], r['dob_raw']) for r in fizo.records})}")
+    print(f"graded people (unique) : {len({core._key(r['name'], r['dob_raw']) for r in grades.records})}")
+    print(f"people to reconcile    : {len(people)}  (union ФИЗО ∪ graded)")
+    print(f"manual protocol files  : {manual_files}")
+    print(f"plan applicants_in_map : {plan['meta']['applicants_in_map']}")
+    print("-" * 72)
+    print("(a) MANUAL xlsx  (cols P/R/U/V by name+dob) vs core.compute_fill")
+    print(f"    checked (rows found)     : {checked_a}")
+    print(f"    people not in any proto  : {len(not_in_proto)} (cannot check — no row)")
+    print(f"    MISMATCHES               : {len(mism_a)}")
+    print("-" * 72)
+    print("(b) PROD plan.json (per-person exercise value + mean_grade) vs core")
+    print(f"    checked (plan-covered)   : {checked_b}")
+    print(f"    MISMATCHES               : {len(mism_b)}")
+    print("=" * 72)
+
+    if mism_a:
+        print("\n(a) up to 10 example mismatches:")
+        for m in mism_a[:10]:
+            print("   ", json.dumps(m, ensure_ascii=False, default=str))
+    if mism_b:
+        print("\n(b) up to 10 example mismatches:")
+        for m in mism_b[:10]:
+            print("   ", json.dumps(m, ensure_ascii=False, default=str))
+
+    summary = {
+        "scoring_mode": core.SCORING_MODE,
+        "people_reconciled": len(people),
+        "a_manual": {
+            "checked": checked_a,
+            "mismatches": len(mism_a),
+            "people_not_in_protocol": len(not_in_proto),
+            "examples": mism_a[:10],
+        },
+        "b_plan": {
+            "checked": checked_b,
+            "mismatches": len(mism_b),
+            "examples": mism_b[:10],
+        },
+        "ok": len(mism_a) == 0 and len(mism_b) == 0,
+    }
+    print("\nSUMMARY_JSON " + json.dumps(summary, ensure_ascii=False, default=str))
+    return 0 if summary["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Зачем

Волна поступления: нужно залить в прод результаты физических испытаний (ФИЗО) и средний балл так, чтобы «Протокол конкурсного отбора» **дословно** совпадал с подписанной ведомостью комиссии — и сырой результат (`8.33`), и балл комиссии (`90`).

Проблема: DAL считает баллы строго (`value <= threshold`), а комиссия округляет к сетке (спринты → 0.1, длинные → вниз к сетке). Из-за этого у ~117/955 человек итоговый балл в DAL отличался от подписанной ведомости. Таблицы перевода в баллы у DAL при этом **совпадают** с утверждёнными нормативами — расходится только субсеточное округление.

## Что сделано

- **Ручка дословной заливки** `POST /api/ams/applicants/{id}/exercise-results/override/`: пишет `value` + `secondary_score` + агрегаты (`strength/speed/endurance_score`, `physical_test_grade`) **как есть, без пересчёта**. Идемпотентная замена набора результатов.
- **Обход пересчёта**: инстанс-флаг `_skip_recalc` в `ExerciseResult.save()` и `post_delete`. Обычный CRUD по-прежнему пересчитывает баллы автоматически.
- **Право** `exercise_results_override.post.all` (только комиссия, без SELF).
- **Экспорт**: бег 1/3 км рендерится как мм:сс (`3.85` → `3:51`), синхронно с фронтовой конвенцией (значение хранится в десятичных минутах).
- **Тесты** (`src/ams/tests/`, 8 шт.): обход пересчёта на save/delete, дословная заливка через эндпоинт, замена устаревших результатов, гейт по правам, форматирование мм:сс.

Строгая логика скоринга DAL **не меняется** — числа комиссии заливаются отдельной ручкой.

## Проверка

- `pytest` — **111 passed**, регрессий нет. Миграция БД **не нужна**.
- Сквозная проверка на dev-стеке: 20 засеянных абитуриентов → заливка через `override` → экспорт протокола → сверка с независимо посчитанным ручным вариантом: **0 расхождений** (320/320 ячеек).
- Протокол показывает `8.33` (сырой спринт), `3:51` (мм:сс), балл комиссии `90`.

## Деплой

Без миграции. После выката:
```
python manage.py register_permissions
```
и выдать `exercise_results_override.post.all` группе комиссии.

## Состав

- `back-end/src/ams/models/physical.py`, `serializers/physical.py`, `views/physical.py`, `urls.py`, `utils/export/comp_sel_protocol.py`, `tests/`
- `tools/dal-fill/` — вспомогательные скрипты заливки/сверки (не деплоятся)

🤖 Generated with [Claude Code](https://claude.com/claude-code)