### PR TITLE
feat(ams): перенос абитуриента между ВУС из таблицы поступающих

### DIFF
--- a/back-end/src/ams/serializers/applicants.py
+++ b/back-end/src/ams/serializers/applicants.py
@@ -17,6 +17,8 @@ from common.serializers.universities import (
 from drf_writable_nested.serializers import WritableNestedModelSerializer
 from rest_framework import serializers
 
+from common.models.milspecialties import Milspecialty
+
 from ams.models.applicants import (
     Applicant,
     ApplicationProcess,
@@ -111,10 +113,15 @@ class ApplicantWithApplicationProcessSerializer(serializers.ModelSerializer):
         read_only=True,
         source="university_info.program.code",
     )
+    program_id = serializers.IntegerField(
+        read_only=True,
+        source="university_info.program.id",
+    )
     faculty = serializers.CharField(
         read_only=True,
         source="university_info.program.faculty.title",
     )
+    milspecialty = MilspecialtySerializer(read_only=True)
     application_process = ApplicationProcessSerializer(read_only=True)
     marital_status = serializers.SerializerMethodField(read_only=True)
 
@@ -128,7 +135,17 @@ class ApplicantWithApplicationProcessSerializer(serializers.ModelSerializer):
             "fullname",
             "birth_date",
             "program_code",
+            "program_id",
             "faculty",
+            "milspecialty",
             "application_process",
             "marital_status",
         ]
+
+
+class ApplicantMilspecialtyMutateSerializer(serializers.Serializer):
+    """Смена ВУС абитуриента (лёгкий перенос без документов)."""
+
+    milspecialty = serializers.PrimaryKeyRelatedField(
+        queryset=Milspecialty.objects.all()
+    )

--- a/back-end/src/ams/tests/test_milspecialty_move.py
+++ b/back-end/src/ams/tests/test_milspecialty_move.py
@@ -1,0 +1,99 @@
+# pylint: disable=redefined-outer-name,invalid-name
+"""Тесты лёгкого переноса абитуриента между ВУС.
+
+Инвариант: эндпоинт меняет только `Applicant.milspecialty`, проверяет
+совместимость с образовательной программой и кампусом, и НЕ трогает
+`ApplicationProcess` (физо/оценки) и документы.
+"""
+import pytest
+
+from common.models.milspecialties import Milspecialty
+
+MILSPECIALTY_URL = "/api/ams/applicants/{pk}/milspecialty/"
+
+
+@pytest.fixture
+def su_client_mo(su_client, superuser):
+    """su_client, которому виден кампус MO (иначе filter_queryset отсечёт запись)."""
+    superuser.campuses = ["MO"]
+    superuser.save()
+    return su_client
+
+
+@pytest.mark.django_db
+def test_move_to_compatible_milspecialty(su_client_mo, applicant):
+    """Совместимый ВУС (доступен для кампуса, выбираем любой программой) -> 200."""
+    target = Milspecialty.objects.create(
+        title="Новый ВУС", code="453000", available_for=["MO"]
+    )
+    ap_before = applicant.application_process
+
+    resp = su_client_mo.patch(
+        MILSPECIALTY_URL.format(pk=applicant.id),
+        {"milspecialty": target.id},
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    assert resp.json()["code"] == "453000"
+
+    applicant.refresh_from_db()
+    assert applicant.milspecialty_id == target.id
+
+    # ApplicationProcess не тронут
+    ap_before.refresh_from_db()
+    assert ap_before.physical_test_grade == 0
+    assert ap_before.mean_grade == 0
+
+
+@pytest.mark.django_db
+def test_move_to_milspecialty_not_selectable_by_program(su_client_mo, applicant):
+    """ВУС, недопустимый для программы абитуриента -> 400, ВУС не меняется."""
+    original_id = applicant.milspecialty_id
+    target = Milspecialty.objects.create(
+        title="Ограниченный ВУС",
+        code="106646-543",
+        available_for=["MO"],
+        selectable_by_every_program=False,
+    )
+
+    resp = su_client_mo.patch(
+        MILSPECIALTY_URL.format(pk=applicant.id),
+        {"milspecialty": target.id},
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+    applicant.refresh_from_db()
+    assert applicant.milspecialty_id == original_id
+
+
+@pytest.mark.django_db
+def test_move_to_milspecialty_not_available_for_campus(su_client_mo, applicant):
+    """ВУС, недоступный для кампуса абитуриента (MO) -> 400."""
+    original_id = applicant.milspecialty_id
+    target = Milspecialty.objects.create(
+        title="Питерский ВУС", code="999999", available_for=["SP"]
+    )
+
+    resp = su_client_mo.patch(
+        MILSPECIALTY_URL.format(pk=applicant.id),
+        {"milspecialty": target.id},
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+
+    applicant.refresh_from_db()
+    assert applicant.milspecialty_id == original_id
+
+
+@pytest.mark.django_db
+def test_move_forbidden_without_permission(test_client, applicant):
+    target = Milspecialty.objects.create(
+        title="Новый ВУС", code="453000", available_for=["MO"]
+    )
+    resp = test_client.patch(
+        MILSPECIALTY_URL.format(pk=applicant.id),
+        {"milspecialty": target.id},
+        content_type="application/json",
+    )
+    assert resp.status_code == 403

--- a/back-end/src/ams/views/applicants.py
+++ b/back-end/src/ams/views/applicants.py
@@ -29,6 +29,7 @@ from conf import settings
 from common.constants import MUTATE_ACTIONS
 
 from common.models.milspecialties import Milspecialty
+from common.serializers.milspecialties import MilspecialtySerializer
 
 from auth.permissions import Permission, BasePermission
 
@@ -41,6 +42,7 @@ from ams.serializers.applicants import (
     ApplicantMutateSerializer,
     ApplicationProcessSerializer,
     ApplicantWithApplicationProcessSerializer,
+    ApplicantMilspecialtyMutateSerializer,
 )
 
 from ams.filters.applicants import ApplicantFilter
@@ -88,7 +90,10 @@ class ApplicantPageNumberPagination(pagination.PageNumberPagination):
 @extend_schema(tags=["applicants"])
 class ApplicantViewSet(QuerySetScopingMixin, ModelViewSet):
     # pylint: disable=too-many-public-methods
-    queryset = Applicant.objects.order_by("surname", "name", "patronymic", "id")
+    queryset = Applicant.objects.select_related(
+        "milspecialty",
+        "university_info__program__faculty",
+    ).order_by("surname", "name", "patronymic", "id")
 
     permission_classes = [ApplicantPermission]
     scoped_permission_class = ApplicantPermission
@@ -142,6 +147,8 @@ class ApplicantViewSet(QuerySetScopingMixin, ModelViewSet):
             return ApplicantWithApplicationProcessSerializer
         if self.action == "application":
             return ApplicationProcessSerializer
+        if self.action == "milspecialty":
+            return ApplicantMilspecialtyMutateSerializer
         if self.action in MUTATE_ACTIONS:
             return ApplicantMutateSerializer
         return ApplicantSerializer
@@ -269,6 +276,38 @@ class ApplicantViewSet(QuerySetScopingMixin, ModelViewSet):
         return Response(
             status=status.HTTP_200_OK,
             data=ApplicationProcessSerializer(instance=updated).data,
+        )
+
+    @action(detail=True, methods=["patch"], permission_classes=[ApplicantPermission])
+    def milspecialty(self, request: Request, pk=None) -> Response:
+        """Перенести абитуриента в другую ВУС (без перегенерации документов)."""
+
+        # pylint: disable=unused-argument,invalid-name
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        applicant = self.get_object()
+        new_milspecialty: Milspecialty = serializer.validated_data["milspecialty"]
+
+        program_id = applicant.university_info.program_id
+        campus = applicant.university_info.program.faculty.campus
+        if (
+            not new_milspecialty.is_selectable_by_program(program_id)
+            or campus not in new_milspecialty.available_for
+        ):
+            return Response(
+                {
+                    "detail": "You can't select this milspecialty with your educational program"
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        applicant.milspecialty = new_milspecialty
+        applicant.save(update_fields=["milspecialty"])
+
+        return Response(
+            status=status.HTTP_200_OK,
+            data=MilspecialtySerializer(instance=new_milspecialty).data,
         )
 
     def generate_students_excel_report(

--- a/front-end/src/api/applicants.js
+++ b/front-end/src/api/applicants.js
@@ -61,6 +61,12 @@ export const updateStudentApplicationInfo = (id, data) => request({
   data,
 });
 
+export const updateApplicantMilspecialty = (id, milspecialtyId) => request({
+  url: `${BASE_API_URL}${applicants}${id}/milspecialty/`,
+  method: "PATCH",
+  data: { milspecialty: milspecialtyId },
+});
+
 export const findApplicant = id => request({
   url: `${BASE_API_URL}${applicants}${id}/`,
   method: "GET",

--- a/front-end/src/components/@ApplicantsDocuments/Table.vue
+++ b/front-end/src/components/@ApplicantsDocuments/Table.vue
@@ -62,6 +62,14 @@
         #editor="{ data: editorData }"
       >
         <SelectInput
+          v-if="field === 'milspecialty'"
+          v-model="editorData.milspecialty_id"
+          :options="milspecialtyOptionsFor(editorData)"
+          :clearable="false"
+          @change="onUpdateMilspecialty(editorData, $event)"
+        />
+
+        <SelectInput
           v-if="field === 'medical_examination'"
           v-model="editorData[field]"
           :options="medicalExaminationOptions"
@@ -105,6 +113,7 @@ import {
 } from "vue-property-decorator";
 import { SelectInput, SingleCheckbox, NumberInput } from "@/common/inputs";
 import { UserModule } from "@/store";
+import { getMilSpecialtiesSelectableByProgram } from "@/api/reference-book";
 
 const fields = {
   index: {
@@ -143,6 +152,12 @@ const fields = {
 };
 
 const additionalFields = {
+  milspecialty: {
+    abbr: "ВУС",
+    title: "Военно-учётная специальность",
+    width: 180,
+    rotate: false,
+  },
   medical_examination: {
     abbr: "Результаты медицинского освидетельствования",
     title: "Результаты медицинского освидетельствования",
@@ -253,9 +268,13 @@ class ApplicantsDocuments extends Vue {
   @Prop({ type: Number, required: true }) startIndex
   @Prop({ type: Function, default: () => true }) onChange
   @Prop({ type: Function, default: undefined }) onOpenPhysicalModal
+  @Prop({ type: String, default: null }) campus
 
   // undefined, so as not to be reactive
   currentEditingValue = undefined
+
+  // Кэш опций ВУС по id образовательной программы (разные строки — разные программы)
+  milspecialtyOptionsByProgram = {}
 
   fields = UserModule.email.includes("study.office")
     ? fields
@@ -270,6 +289,7 @@ class ApplicantsDocuments extends Vue {
     "mean_grade",
     "medical_examination",
     "prof_psy_selection",
+    "milspecialty",
   ]
 
   medicalExaminationOptions = medicalExaminationOptions
@@ -286,6 +306,62 @@ class ApplicantsDocuments extends Vue {
 
   savePrevValue({ data, field }) {
     this.currentEditingValue = data[field];
+  }
+
+  milspecialtyOptionsFor(row) {
+    return this.milspecialtyOptionsByProgram[row.program_id] || [];
+  }
+
+  // Предзагрузка опций ВУС по всем программам, встречающимся в текущих данных.
+  // Делается заранее (а не по cell-edit-init), т.к. PrimeColumn.field — функция,
+  // и событие редактирования не даёт строкового имени поля.
+  preloadMilspecialtyOptions() {
+    if (!this.fields.milspecialty) {
+      return;
+    }
+    const programIds = [
+      ...new Set((this.data || []).map(row => row.program_id).filter(Boolean)),
+    ];
+    programIds.forEach(programId => this.loadMilspecialtyOptions(programId));
+  }
+
+  async loadMilspecialtyOptions(programId) {
+    if (!programId || this.milspecialtyOptionsByProgram[programId]) {
+      return;
+    }
+    try {
+      const { data } = await getMilSpecialtiesSelectableByProgram(
+        this.campus,
+        programId,
+      );
+      const options = data
+        .filter(item => item.selectable_by_program)
+        .map(item => ({
+          label: item.title ? `${item.code} - ${item.title}` : item.code,
+          value: item.id,
+          code: item.code,
+          title: item.title,
+        }));
+      this.$set(this.milspecialtyOptionsByProgram, programId, options);
+    } catch (e) {
+      console.error("Не удалось загрузить список ВУС", e);
+    }
+  }
+
+  async onUpdateMilspecialty(data, newId) {
+    const prevId = data.milspecialty_id;
+    if (await this.onChange({ id: data.id, key: "milspecialty", value: newId })) {
+      const option = this.milspecialtyOptionsFor(data).find(o => o.value === newId);
+      if (option) {
+        // eslint-disable-next-line no-param-reassign
+        data.milspecialty = { id: newId, code: option.code, title: option.title };
+      }
+      // eslint-disable-next-line no-param-reassign
+      data.milspecialty_id = newId;
+    } else {
+      // eslint-disable-next-line no-param-reassign
+      data.milspecialty_id = prevId;
+    }
   }
 
   headerStyle(rotate, width) {
@@ -342,6 +418,7 @@ class ApplicantsDocuments extends Vue {
   @Watch("data", { immediate: true, deep: true })
   onDataChanged(newVal, oldVal) {
     this.synchronizeHeights();
+    this.preloadMilspecialtyOptions();
   }
 
   getCellText(data, field) {
@@ -359,6 +436,15 @@ class ApplicantsDocuments extends Vue {
 
     if (field === "prof_psy_selection") {
       return getSelectLabel(data[field], profPsySelection);
+    }
+
+    if (field === "milspecialty") {
+      if (!data.milspecialty) {
+        return "—";
+      }
+      return data.milspecialty.title
+        ? `${data.milspecialty.code} - ${data.milspecialty.title}`
+        : data.milspecialty.code;
     }
 
     if (checkboxesFields.includes(field)) {

--- a/front-end/src/views/ApplicantsDocuments/index.vue
+++ b/front-end/src/views/ApplicantsDocuments/index.vue
@@ -119,6 +119,7 @@
         :key="`${currentPage}-${entriesAmount}`"
         :class="$style.table"
         :data="data"
+        :campus="selectedCampus"
         :start-index="(currentPage - 1) * pageSize"
         :on-change="onUpdate"
         :on-open-physical-modal="openPhysicalModal"
@@ -153,6 +154,7 @@ import moment from "moment";
 import {
   getApplicationsStudents,
   updateStudentApplicationInfo,
+  updateApplicantMilspecialty,
   APPLICATIONS_EXPORT_LINK,
   APPLICATIONS_CSP_EXPORT_LINK,
   APPLICATIONS_DET_EXPORT_LINK,
@@ -294,6 +296,9 @@ export default {
         passport: item.passport,
         personal_documents_info: item.personal_documents_info,
         program: item.program_code,
+        program_id: item.program_id,
+        milspecialty: item.milspecialty,
+        milspecialty_id: item.milspecialty?.id,
         ...item.application_process,
       }));
       this.entriesAmount = data.count;
@@ -306,7 +311,11 @@ export default {
 
     async onUpdate({ id, key, value }) {
       try {
-        await updateStudentApplicationInfo(id, { [key]: value });
+        if (key === "milspecialty") {
+          await updateApplicantMilspecialty(id, value);
+        } else {
+          await updateStudentApplicationInfo(id, { [key]: value });
+        }
         return true;
       } catch (e) {
         console.error("Не удалось обновить данные студента о поступлении: ", e);


### PR DESCRIPTION
## Контекст

Во время активного поступления комиссия часто просит перенести абитуриента из одной
ВУС (военно-учётной специальности) в другую. Раньше сменить ВУС можно было только
тяжёлым `PUT /api/ams/applicants/{id}/`: он требует все вложенные данные, сверяет
`corporate_email`, переназначает кампус и в PROD перегенерирует документы. В таблице
поступающих (`/applications/`) ВУС вообще не отображался и action переноса не было.

Этот PR добавляет лёгкий точечный перенос прямо из таблицы.

> Физо-скоринг (`ams/physical/scoring.py`) зависит только от возраста, упражнения и
> результата — **не** от ВУС. Поэтому перенос не требует пересчёта баллов и не трогает
> `ApplicationProcess`.

## Что изменилось

### Back-end
- **`PATCH /api/ams/applicants/{id}/milspecialty/`** (body `{ "milspecialty": <id> }`) —
  меняет только `Applicant.milspecialty`. Проверяет `is_selectable_by_program` и
  доступность ВУС для кампуса абитуриента; при несовместимости → `400`. **Документы не
  перегенерирует** (осознанно, в отличие от `update()`).
- `ApplicantMilspecialtyMutateSerializer` — валидация id ВУС.
- `ApplicantWithApplicationProcessSerializer` теперь отдаёт `milspecialty` и `program_id`
  (для колонки и загрузки допустимых опций по программе строки).
- `queryset.select_related("milspecialty", "university_info__program__faculty")` — против N+1.

### Front-end
- Колонка **«ВУС»** в таблице поступающих (видна комиссии, скрыта у `study.office`).
- Inline-`select` в ячейке — как `medical_examination`/`prof_psy_selection`. Опции берутся
  через `getMilSpecialtiesSelectableByProgram(campus, programId)` и фильтруются по
  `selectable_by_program`; предзагрузка на `@Watch("data")` + кэш по `program_id`.
- `updateApplicantMilspecialty` в `api/applicants.js`; ветка в `onUpdate`.

## Проверка (e2e, Playwright)

Прогнано вживую на дев-стеке (`superuser@mail.com`, кампус Москва, 2026):

**1. Колонка «ВУС» в таблице поступающих**
![Колонка ВУС](https://raw.githubusercontent.com/hse-mtc/dal/assets/vus-move-screenshots/docs/screenshots/vus-move/01-column.png)

**2. Inline-выбор нового ВУС — список отфильтрован по образовательной программе строки**
![Выбор ВУС](https://raw.githubusercontent.com/hse-mtc/dal/assets/vus-move-screenshots/docs/screenshots/vus-move/02-dropdown.png)

**3. После выбора → `PATCH /milspecialty/` → 200; значение сохраняется после перезагрузки**
![После переноса](https://raw.githubusercontent.com/hse-mtc/dal/assets/vus-move-screenshots/docs/screenshots/vus-move/03-after-reload.png)

Сценарий: у «Иванов И.И.» (программа 09.03.01) ВУС `453100` → выбран `751100 - Защита
информационных технологий` → запрос `PATCH /api/ams/applicants/1/milspecialty/ 200 OK` →
после reload ВУС остаётся `751100` (сохранено в БД).

### Тесты
- `pytest src/ams/` → **12 passed** (в т.ч. 4 новых в `test_milspecialty_move.py`:
  успех / несовместимо с программой / недоступно для кампуса / без прав → 403).
- ESLint по изменённым файлам — 0 ошибок. `black` — чисто.

## Замечания
- База PR — `feat/ams-physical-manual-override` (стек поверх #739), т.к. новый тест
  использует фикстуру `applicant` из `ams/tests/conftest.py`, добавленную в той ветке.
  После мёржа #739 GitHub переназначит базу на `master`.
- Скриншоты хранятся отдельно (ветка `assets/vus-move-screenshots`, вне этого PR),
  чтобы не тащить бинарники в дифф — здесь они только в описании.
- Массовый перенос и фильтр по ВУС — возможные follow-up (в объём не входят).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
